### PR TITLE
Imp:  attachments

### DIFF
--- a/request.go
+++ b/request.go
@@ -321,7 +321,11 @@ func unpackRequestBody(buf []byte, reqObj interface{}) error {
 	if err != nil {
 		return perrors.WithStack(err)
 	}
-	req[6] = ToMapStringString(attachments.(map[interface{}]interface{}))
+	if v, ok := attachments.(map[interface{}]interface{}); ok {
+		req[6] = ToMapStringString(v)
+	} else {
+		return perrors.Errorf("get wrong attachments: %+v", attachments)
+	}
 
 	return nil
 }

--- a/request.go
+++ b/request.go
@@ -323,11 +323,10 @@ func unpackRequestBody(buf []byte, reqObj interface{}) error {
 	}
 	if v, ok := attachments.(map[interface{}]interface{}); ok {
 		req[6] = ToMapStringString(v)
-	} else {
-		return perrors.Errorf("get wrong attachments: %+v", attachments)
+		return nil
 	}
 
-	return nil
+	return perrors.Errorf("get wrong attachments: %+v", attachments)
 }
 
 func ToMapStringString(origin map[interface{}]interface{}) map[string]string {

--- a/request.go
+++ b/request.go
@@ -321,7 +321,19 @@ func unpackRequestBody(buf []byte, reqObj interface{}) error {
 	if err != nil {
 		return perrors.WithStack(err)
 	}
-	req[6] = attachments
+	req[6] = ToMapStringString(attachments.(map[interface{}]interface{}))
 
 	return nil
+}
+
+func ToMapStringString(origin map[interface{}]interface{}) map[string]string {
+	dest := make(map[string]string)
+	for k, v := range origin {
+		if kv, ok := k.(string); ok {
+			if vv, ok := v.(string); ok {
+				dest[kv] = vv
+			}
+		}
+	}
+	return dest
 }

--- a/response.go
+++ b/response.go
@@ -174,8 +174,12 @@ func unpackResponseBody(buf []byte, resp interface{}) error {
 			if err != nil {
 				return perrors.WithStack(err)
 			}
-			atta := ToMapStringString(attachments.(map[interface{}]interface{}))
-			response.Attachments = atta
+			if v, ok := attachments.(map[interface{}]interface{}); ok {
+				atta := ToMapStringString(v)
+				response.Attachments = atta
+			} else {
+				return perrors.Errorf("get wrong attachments: %+v", attachments)
+			}
 		}
 
 		if e, ok := expt.(error); ok {
@@ -195,8 +199,12 @@ func unpackResponseBody(buf []byte, resp interface{}) error {
 			if err != nil {
 				return perrors.WithStack(err)
 			}
-			atta := ToMapStringString(attachments.(map[interface{}]interface{}))
-			response.Attachments = atta
+			if v, ok := attachments.(map[interface{}]interface{}); ok {
+				atta := ToMapStringString(v)
+				response.Attachments = atta
+			} else {
+				return perrors.Errorf("get wrong attachments: %+v", attachments)
+			}
 		}
 
 		return perrors.WithStack(ReflectResponse(rsp, response.RspObj))
@@ -207,8 +215,12 @@ func unpackResponseBody(buf []byte, resp interface{}) error {
 			if err != nil {
 				return perrors.WithStack(err)
 			}
-			atta := ToMapStringString(attachments.(map[interface{}]interface{}))
-			response.Attachments = atta
+			if v, ok := attachments.(map[interface{}]interface{}); ok {
+				atta := ToMapStringString(v)
+				response.Attachments = atta
+			} else {
+				return perrors.Errorf("get wrong attachments: %+v", attachments)
+			}
 		}
 		return nil
 	}

--- a/response.go
+++ b/response.go
@@ -174,12 +174,8 @@ func unpackResponseBody(buf []byte, resp interface{}) error {
 			if err != nil {
 				return perrors.WithStack(err)
 			}
-			atta, ok := attachments.(map[string]string)
-			if ok {
-				response.Attachments = atta
-			} else {
-				return perrors.Errorf("get wrong attachments: %+v", atta)
-			}
+			atta := ToMapStringString(attachments.(map[interface{}]interface{}))
+			response.Attachments = atta
 		}
 
 		if e, ok := expt.(error); ok {
@@ -199,12 +195,8 @@ func unpackResponseBody(buf []byte, resp interface{}) error {
 			if err != nil {
 				return perrors.WithStack(err)
 			}
-			atta, ok := attachments.(map[string]string)
-			if ok {
-				response.Attachments = atta
-			} else {
-				return perrors.Errorf("get wrong attachments: %+v", atta)
-			}
+			atta := ToMapStringString(attachments.(map[interface{}]interface{}))
+			response.Attachments = atta
 		}
 
 		return perrors.WithStack(ReflectResponse(rsp, response.RspObj))
@@ -215,12 +207,8 @@ func unpackResponseBody(buf []byte, resp interface{}) error {
 			if err != nil {
 				return perrors.WithStack(err)
 			}
-			atta, ok := attachments.(map[string]string)
-			if ok {
-				response.Attachments = atta
-			} else {
-				return perrors.Errorf("get wrong attachments: %+v", atta)
-			}
+			atta := ToMapStringString(attachments.(map[interface{}]interface{}))
+			response.Attachments = atta
 		}
 		return nil
 	}


### PR DESCRIPTION
**What this PR does**:

Because the `map  `can only be resolved to `map[interface{}]interface{}` in the hessian2, I must be convert to `map[string]string`.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note

```