### PR TITLE
fix: can't duplicately decode Serializer object

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,5 +18,11 @@ lint:
 
 lint2:
 	golangci-lint run
+
+format:
+	go fmt
+
 test:
 	go test
+
+all: format test

--- a/object.go
+++ b/object.go
@@ -550,9 +550,7 @@ func (d *Decoder) decObject(flag int32) (interface{}, error) {
 		cls, _ = clsDef.(classInfo)
 		//add to slice
 		d.appendClsDef(cls)
-		if c, ok := GetSerializer(cls.javaName); ok {
-			return c.DecObject(d)
-		}
+
 		return d.DecodeValue()
 
 	case tag == BC_OBJECT:
@@ -572,6 +570,10 @@ func (d *Decoder) decObject(flag int32) (interface{}, error) {
 			return d.decEnum(cls.javaName, TAG_READ)
 		}
 
+		if c, ok := GetSerializer(cls.javaName); ok {
+			return c.DecObject(d, typ, cls)
+		}
+
 		return d.decInstance(typ, cls)
 
 	case BC_OBJECT_DIRECT <= tag && tag <= (BC_OBJECT_DIRECT+OBJECT_DIRECT_MAX):
@@ -584,6 +586,10 @@ func (d *Decoder) decObject(flag int32) (interface{}, error) {
 		}
 		if typ.Implements(javaEnumType) {
 			return d.decEnum(cls.javaName, TAG_READ)
+		}
+
+		if c, ok := GetSerializer(cls.javaName); ok {
+			return c.DecObject(d, typ, cls)
 		}
 
 		return d.decInstance(typ, cls)

--- a/serialize.go
+++ b/serialize.go
@@ -19,6 +19,7 @@ package hessian
 
 import (
 	big "github.com/dubbogo/gost/math/big"
+	"reflect"
 )
 
 func init() {
@@ -28,7 +29,7 @@ func init() {
 
 type Serializer interface {
 	EncObject(*Encoder, POJO) error
-	DecObject(*Decoder) (interface{}, error)
+	DecObject(*Decoder, reflect.Type, classInfo) (interface{}, error)
 }
 
 var serializerMap = make(map[string]Serializer, 16)
@@ -53,8 +54,8 @@ func (DecimalSerializer) EncObject(e *Encoder, v POJO) error {
 	return e.encObject(decimal)
 }
 
-func (DecimalSerializer) DecObject(d *Decoder) (interface{}, error) {
-	dec, err := d.DecodeValue()
+func (DecimalSerializer) DecObject(d *Decoder, typ reflect.Type, cls classInfo) (interface{}, error) {
+	dec, err := d.decInstance(typ, cls)
 	if err != nil {
 		return nil, err
 	}

--- a/serialize.go
+++ b/serialize.go
@@ -18,8 +18,11 @@
 package hessian
 
 import (
-	big "github.com/dubbogo/gost/math/big"
 	"reflect"
+)
+
+import (
+	big "github.com/dubbogo/gost/math/big"
 )
 
 func init() {

--- a/serialize_test.go
+++ b/serialize_test.go
@@ -69,3 +69,25 @@ func doTestDecimal(t *testing.T, method, content string) {
 		assert.Equal(t, content, r.(*big.Decimal).String())
 	})
 }
+
+func TestDecimalListGoDecode(t *testing.T) {
+	data := []string{
+		"123.4",
+		"123.45",
+		"123.456",
+	}
+
+	out, err := decodeJavaResponse(`customReplyTypedFixedList_BigDecimal`, ``, false)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	resp := out.([]*big.Decimal)
+	for i := range data {
+		gotDecimal := resp[i]
+		if gotDecimal.String() != data[i] {
+			t.Errorf("java: %s go: %s", gotDecimal.String(), data[i])
+		}
+	}
+}

--- a/test_hessian/src/main/java/test/TestCustomReply.java
+++ b/test_hessian/src/main/java/test/TestCustomReply.java
@@ -350,6 +350,16 @@ public class TestCustomReply {
         output.flush();
     }
 
+    public void customReplyTypedFixedList_BigDecimal() throws Exception {
+        BigDecimal[] decimals = new BigDecimal[]{
+                new BigDecimal("123.4"),
+                new BigDecimal("123.45"),
+                new BigDecimal("123.456"),
+        };
+        output.writeObject(decimals);
+        output.flush();
+    }
+
     public void customReplyTypedFixedDateNull() throws Exception {
         DateDemo demo = new DateDemo("zhangshan", null, null);
         output.writeObject(demo);


### PR DESCRIPTION

**What this PR does**:
it can only decode Serializer object once. this PR fix it to allow duplicately decode Serializer objects. 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
currently, it only decode  Serializer object when meeting class definition, but the Serializer object may occurs many times. 

**Does this PR introduce a user-facing change?**:

```release-note
fix: can't duplicately decode Serializer object
```