### PR TITLE
Flat anonymous  struct field

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,13 @@ So we can maintain a cross language type mapping:
 
 ```go
 type Circular struct {
-	Num      int
+	Value
 	Previous *Circular
 	Next     *Circular
+}
+
+type Value struct {
+	Num int
 }
 
 func (Circular) JavaClassName() string {

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ It's a golang hessian library used by [Apache/dubbo-go](https://github.com/apach
 * [Java Bigdecimal](https://github.com/apache/dubbo-go-hessian2/issues/89)
 * [Java Date & Time](https://github.com/apache/dubbo-go-hessian2/issues/90)
 * [Java Generic Invokation](https://github.com/apache/dubbo-go-hessian2/issues/84)
+* [Java Extends](https://github.com/apache/dubbo-go-hessian2/issues/157)
 * [Dubbo Attachements](https://github.com/apache/dubbo-go-hessian2/issues/49)
 * [Skipping unregistered POJO](https://github.com/apache/dubbo-go-hessian2/pull/128)
 * [Emoji](https://github.com/apache/dubbo-go-hessian2/issues/129)

--- a/object_test.go
+++ b/object_test.go
@@ -558,3 +558,31 @@ func TestSkip(t *testing.T) {
 
 	testDecodeFrameworkWithSkip(t, "customReplyTypedFixedList_Object", make([]Object, 1))
 }
+
+type Animal struct {
+	Name string
+}
+type Dog struct {
+	Animal
+	Gender string
+}
+
+func (dog *Dog) JavaClassName() string {
+	return "test.Dog"
+}
+
+// see https://github.com/apache/dubbo-go-hessian2/issues/149
+func TestIssue149_EmbedStructGoDecode(t *testing.T) {
+	RegisterPOJO(&Dog{})
+
+	got, err := decodeJavaResponse(`customReplyExtendClass`, ``, false)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	want := &Dog{Animal{`a dog`}, `male`}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("want %v got %v", want, got)
+	}
+}

--- a/object_test.go
+++ b/object_test.go
@@ -562,27 +562,55 @@ func TestSkip(t *testing.T) {
 type Animal struct {
 	Name string
 }
+
+func (a Animal) JavaClassName() string {
+	return "test.Animal"
+}
+
 type Dog struct {
 	Animal
 	Gender string
 }
 
-func (dog *Dog) JavaClassName() string {
+func (dog Dog) JavaClassName() string {
 	return "test.Dog"
+}
+
+type DogAll struct {
+	All    bool
+	Name   string
+	Gender string
+}
+
+func (dog *DogAll) JavaClassName() string {
+	return "test.DogAll"
 }
 
 // see https://github.com/apache/dubbo-go-hessian2/issues/149
 func TestIssue149_EmbedStructGoDecode(t *testing.T) {
-	RegisterPOJO(&Dog{})
+	t.Run(`extends to embed`, func(t *testing.T) {
+		RegisterPOJO(&Dog{})
+		got, err := decodeJavaResponse(`customReplyExtendClass`, ``, false)
+		if err != nil {
+			t.Error(err)
+		}
 
-	got, err := decodeJavaResponse(`customReplyExtendClass`, ``, false)
-	if err != nil {
-		t.Error(err)
-		return
-	}
+		want := &Dog{Animal{`a dog`}, `male`}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("want %v got %v", want, got)
+		}
+	})
 
-	want := &Dog{Animal{`a dog`}, `male`}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("want %v got %v", want, got)
-	}
+	t.Run(`extends to all fields`, func(t *testing.T) {
+		RegisterPOJO(&DogAll{})
+		got, err := decodeJavaResponse(`customReplyExtendClassToSingleStruct`, ``, false)
+		if err != nil {
+			t.Error(err)
+		}
+
+		want := &DogAll{true, `a dog`, `male`}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("want %v got %v", want, got)
+		}
+	})
 }

--- a/object_test.go
+++ b/object_test.go
@@ -563,13 +563,19 @@ type Animal struct {
 	Name string
 }
 
+type animal struct {
+	Name string
+}
+
 func (a Animal) JavaClassName() string {
 	return "test.Animal"
 }
 
 type Dog struct {
 	Animal
-	Gender string
+	animal
+	Gender  string
+	DogName string `hessian:"-"`
 }
 
 func (dog Dog) JavaClassName() string {
@@ -595,7 +601,7 @@ func TestIssue149_EmbedStructGoDecode(t *testing.T) {
 			t.Error(err)
 		}
 
-		want := &Dog{Animal{`a dog`}, `male`}
+		want := &Dog{Animal{`a dog`}, animal{}, `male`, ``}
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("want %v got %v", want, got)
 		}
@@ -613,4 +619,14 @@ func TestIssue149_EmbedStructGoDecode(t *testing.T) {
 			t.Errorf("want %v got %v", want, got)
 		}
 	})
+}
+func TestIssue150_EmbedStructJavaDecode(t *testing.T) {
+	RegisterPOJO(&Dog{})
+	RegisterPOJO(&Animal{})
+
+	dog := &Dog{Animal{`a dog`}, animal{}, `male`, `DogName`}
+	bytes, err := encodeTarget(dog)
+	t.Log(string(bytes), err)
+
+	testJavaDecode(t, "customArgTypedFixed_Extends", dog)
 }

--- a/test_hessian/src/main/java/test/TestCustomDecode.java
+++ b/test_hessian/src/main/java/test/TestCustomDecode.java
@@ -187,6 +187,11 @@ public class TestCustomDecode {
         return o.toString().equals("100.256");
     }
 
+    public Object customArgTypedFixed_Extends() throws Exception {
+        Dog o = (Dog) input.readObject();
+        return o.name.equals("a dog") && o.gender.equals("male");
+    }
+
     public Object customArgTypedFixed_DateNull() throws Exception {
         DateDemo o = (DateDemo) input.readObject();
         return o.getDate() == null && o.getDate1() == null;

--- a/test_hessian/src/main/java/test/TestCustomReply.java
+++ b/test_hessian/src/main/java/test/TestCustomReply.java
@@ -422,6 +422,28 @@ public class TestCustomReply {
         output.flush();
     }
 
+    public void customReplyExtendClass() throws Exception {
+        Dog dog = new Dog();
+        dog.name = "a dog";
+        dog.gender = "male";
+        output.writeObject(dog);
+        output.flush();
+    }
+}
+
+interface Leg {
+    public int legConnt = 4;
+    public String legName = "AAA";
+}
+
+class Animal {
+    public String name;
+}
+
+class Dog extends Animal implements java.io.Serializable, Leg {
+    public String gender;
+
+    private static final long serialVersionUID = 610887488714367777L;
 }
 
 class TypedListTest implements Serializable {

--- a/test_hessian/src/main/java/test/TestCustomReply.java
+++ b/test_hessian/src/main/java/test/TestCustomReply.java
@@ -440,10 +440,8 @@ class Animal {
     public String name;
 }
 
-class Dog extends Animal implements java.io.Serializable, Leg {
+class Dog extends Animal implements Serializable, Leg {
     public String gender;
-
-    private static final long serialVersionUID = 610887488714367777L;
 }
 
 class TypedListTest implements Serializable {

--- a/test_hessian/src/main/java/test/TestCustomReply.java
+++ b/test_hessian/src/main/java/test/TestCustomReply.java
@@ -429,11 +429,18 @@ public class TestCustomReply {
         output.writeObject(dog);
         output.flush();
     }
+
+    public void customReplyExtendClassToSingleStruct() throws Exception {
+        Dog dog = new DogAll();
+        dog.name = "a dog";
+        dog.gender = "male";
+        output.writeObject(dog);
+        output.flush();
+    }
 }
 
 interface Leg {
     public int legConnt = 4;
-    public String legName = "AAA";
 }
 
 class Animal {
@@ -442,6 +449,10 @@ class Animal {
 
 class Dog extends Animal implements Serializable, Leg {
     public String gender;
+}
+
+class DogAll extends Dog {
+    public boolean all = true;
 }
 
 class TypedListTest implements Serializable {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

- flat anonymons fields
- ignore field with tag `hessian:"-"`

#153 

**Special notes for your reviewer**:

when find a anonymous field in scanning struct's fields, encoding/json will flat field immediately. but I put the field to queue and flat latter


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
result of encode(object) has changed,
but the method decode is compatibility with previous version
```