### PR TITLE
Fix #181: float32 accuracy issue

### DIFF
--- a/double.go
+++ b/double.go
@@ -20,6 +20,7 @@ package hessian
 import (
 	"encoding/binary"
 	"math"
+	"strconv"
 )
 
 import (
@@ -82,8 +83,16 @@ func encFloat32(b []byte, v float32) []byte {
 	}
 
 END:
-	iv := int32(v * 1000)
-	return encByte(b, BC_DOUBLE_MILL, byte(iv>>24), byte(iv>>16), byte(iv>>8), byte(iv))
+	if float32(int32(v * 1000)) == v * 1000 {
+		iv := int32(v * 1000)
+		return encByte(b, BC_DOUBLE_MILL, byte(iv>>24), byte(iv>>16), byte(iv>>8), byte(iv))
+	} else {
+		str := strconv.FormatFloat(float64(v), 'f', -1, 32)
+		d, _ := strconv.ParseFloat(str, 64)
+		bits := math.Float64bits(d)
+		return encByte(b, BC_DOUBLE, byte(bits>>56), byte(bits>>48), byte(bits>>40),
+			byte(bits>>32), byte(bits>>24), byte(bits>>16), byte(bits>>8), byte(bits))
+	}
 }
 
 /////////////////////////////////////////

--- a/double.go
+++ b/double.go
@@ -62,6 +62,30 @@ END:
 		byte(bits>>32), byte(bits>>24), byte(bits>>16), byte(bits>>8), byte(bits))
 }
 
+func encFloat32(b []byte, v float32) []byte {
+	fv := float32(int32(v))
+	if fv == v {
+		iv := int32(v)
+		switch iv {
+		case 0:
+			return encByte(b, BC_DOUBLE_ZERO)
+		case 1:
+			return encByte(b, BC_DOUBLE_ONE)
+		}
+		if iv >= -0x80 && iv < 0x80 {
+			return encByte(b, BC_DOUBLE_BYTE, byte(iv))
+		} else if iv >= -0x8000 && iv < 0x8000 {
+			return encByte(b, BC_DOUBLE_SHORT, byte(iv>>8), byte(iv))
+		}
+
+		goto END
+	}
+
+END:
+	iv := int32(v * 1000)
+	return encByte(b, BC_DOUBLE_MILL, byte(iv>>24), byte(iv>>16), byte(iv>>8), byte(iv))
+}
+
 /////////////////////////////////////////
 // Double
 /////////////////////////////////////////

--- a/double.go
+++ b/double.go
@@ -83,7 +83,7 @@ func encFloat32(b []byte, v float32) []byte {
 	}
 
 END:
-	if float32(int32(v * 1000)) == v * 1000 {
+	if float32(int32(v*1000)) == v*1000 {
 		iv := int32(v * 1000)
 		return encByte(b, BC_DOUBLE_MILL, byte(iv>>24), byte(iv>>16), byte(iv>>8), byte(iv))
 	} else {

--- a/double_test.go
+++ b/double_test.go
@@ -42,6 +42,28 @@ func TestEncDouble(t *testing.T) {
 	t.Logf("decode(%v) = %v, %v\n", v, res, err)
 }
 
+func TestIssue181(t *testing.T) {
+	var (
+		v   float32
+		err error
+		e   *Encoder
+		d   *Decoder
+		res interface{}
+	)
+
+	e = NewEncoder()
+	v = 99.8
+	e.Encode(v)
+	if len(e.Buffer()) == 0 {
+		t.Fail()
+	}
+
+	// res would be '99.800003' without patches in PR #196
+	d = NewDecoder(e.Buffer())
+	res, err = d.Decode()
+	t.Logf("decode(%v) = %v, %v\n", v, res, err)
+}
+
 func TestDouble(t *testing.T) {
 	testDecodeFramework(t, "replyDouble_0_0", 0.0)
 	testDecodeFramework(t, "replyDouble_0_001", 0.001)

--- a/double_test.go
+++ b/double_test.go
@@ -61,7 +61,12 @@ func TestIssue181(t *testing.T) {
 	// res would be '99.800003' without patches in PR #196
 	d = NewDecoder(e.Buffer())
 	res, err = d.Decode()
-	t.Logf("decode(%v) = %v, %v\n", v, res, err)
+	f := res.(float64)
+	if float32(f) != v {
+		t.Errorf("decode(%v) = %v, %v\n", v, res, err)
+		return
+	}
+	t.Logf("decode(%v) = %v\n", v, res)
 }
 
 func TestDouble(t *testing.T) {

--- a/encode.go
+++ b/encode.go
@@ -112,6 +112,8 @@ func (e *Encoder) Encode(v interface{}) error {
 			// e.buffer = encDateInMimute(v.(time.Time), e.buffer)
 		}
 
+	// float32 cast to float64 will cause accuracy issue.
+	// float32-->string-->float64, the transformation can solve it.
 	case float32:
 		str := strconv.FormatFloat(float64(val), 'f', -1, 32)
 		d, _ := strconv.ParseFloat(str, 64)

--- a/encode.go
+++ b/encode.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"time"
 	"unsafe"
+	"strconv"
 )
 
 import (
@@ -112,7 +113,9 @@ func (e *Encoder) Encode(v interface{}) error {
 		}
 
 	case float32:
-		e.buffer = encFloat(e.buffer, float64(val))
+		str := strconv.FormatFloat(float64(val), 'f', -1, 32)
+		d, _ := strconv.ParseFloat(str, 64)
+		e.buffer = encFloat(e.buffer, d)
 
 	case float64:
 		e.buffer = encFloat(e.buffer, val)

--- a/encode.go
+++ b/encode.go
@@ -19,9 +19,9 @@ package hessian
 
 import (
 	"reflect"
+	"strconv"
 	"time"
 	"unsafe"
-	"strconv"
 )
 
 import (

--- a/encode.go
+++ b/encode.go
@@ -19,7 +19,6 @@ package hessian
 
 import (
 	"reflect"
-	"strconv"
 	"time"
 	"unsafe"
 )
@@ -112,12 +111,8 @@ func (e *Encoder) Encode(v interface{}) error {
 			// e.buffer = encDateInMimute(v.(time.Time), e.buffer)
 		}
 
-	// float32 cast to float64 will cause accuracy issue.
-	// float32-->string-->float64, the transformation can solve it.
 	case float32:
-		str := strconv.FormatFloat(float64(val), 'f', -1, 32)
-		d, _ := strconv.ParseFloat(str, 64)
-		e.buffer = encFloat(e.buffer, d)
+		e.buffer = encFloat32(e.buffer, val)
 
 	case float64:
 		e.buffer = encFloat(e.buffer, val)


### PR DESCRIPTION
The issue accuracy is caused by casting from float32 to float64 when encoding, which leads to extra decimal appended to the original float. Transformation from float32 to string, and then float64 could avoid this issue.