### PR TITLE
Add GetStackTrace method into Throwabler and its implements

### DIFF
--- a/java_exception/annotation_type_mismatch_exception.go
+++ b/java_exception/annotation_type_mismatch_exception.go
@@ -42,3 +42,8 @@ func (e AnnotationTypeMismatchException) Error() string {
 func (AnnotationTypeMismatchException) JavaClassName() string {
 	return "java.lang.annotation.AnnotationTypeMismatchException"
 }
+
+// equals to getStackTrace in java
+func (e AnnotationTypeMismatchException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/arithmetic_exception.go
+++ b/java_exception/arithmetic_exception.go
@@ -40,3 +40,8 @@ func (e ArithmeticException) Error() string {
 func (ArithmeticException) JavaClassName() string {
 	return "java.lang.ArithmeticException"
 }
+
+// equals to getStackTrace in java
+func (e ArithmeticException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/array_index_out_of_bounds_exception.go
+++ b/java_exception/array_index_out_of_bounds_exception.go
@@ -40,3 +40,8 @@ func (e ArrayIndexOutOfBoundsException) Error() string {
 func (ArrayIndexOutOfBoundsException) JavaClassName() string {
 	return "java.lang.ArrayIndexOutOfBoundsException"
 }
+
+// equals to getStackTrace in java
+func (e ArrayIndexOutOfBoundsException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/array_store_exception.go
+++ b/java_exception/array_store_exception.go
@@ -40,3 +40,8 @@ func (e ArrayStoreException) Error() string {
 func (ArrayStoreException) JavaClassName() string {
 	return "java.lang.ArrayStoreException"
 }
+
+// equals to getStackTrace in java
+func (e ArrayStoreException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/backing_store_exception.go
+++ b/java_exception/backing_store_exception.go
@@ -40,3 +40,8 @@ func (e BackingStoreException) Error() string {
 func (BackingStoreException) JavaClassName() string {
 	return "java.util.prefs.BackingStoreException"
 }
+
+// equals to getStackTrace in java
+func (e BackingStoreException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/broken_barrier_exception.go
+++ b/java_exception/broken_barrier_exception.go
@@ -40,3 +40,8 @@ func (e BrokenBarrierException) Error() string {
 func (BrokenBarrierException) JavaClassName() string {
 	return "java.util.concurrent.BrokenBarrierException"
 }
+
+// equals to getStackTrace in java
+func (e BrokenBarrierException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/cancellation_exception.go
+++ b/java_exception/cancellation_exception.go
@@ -40,3 +40,8 @@ func (e CancellationException) Error() string {
 func (CancellationException) JavaClassName() string {
 	return "java.util.concurrent.CancellationException"
 }
+
+// equals to getStackTrace in java
+func (e CancellationException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/class_not_found_exception.go
+++ b/java_exception/class_not_found_exception.go
@@ -41,3 +41,8 @@ func (e ClassNotFoundException) Error() string {
 func (ClassNotFoundException) JavaClassName() string {
 	return "java.lang.ClassNotFoundException"
 }
+
+// equals to getStackTrace in java
+func (e ClassNotFoundException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/classc_cast_exception.go
+++ b/java_exception/classc_cast_exception.go
@@ -40,3 +40,8 @@ func (e ClassCastException) Error() string {
 func (ClassCastException) JavaClassName() string {
 	return "java.lang.ClassCastException"
 }
+
+// equals to getStackTrace in java
+func (e ClassCastException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/clone_not_supported_exception.go
+++ b/java_exception/clone_not_supported_exception.go
@@ -44,3 +44,8 @@ func (e CloneNotSupportedException) Error() string {
 func (CloneNotSupportedException) JavaClassName() string {
 	return "java.lang.CloneNotSupportedException"
 }
+
+// equals to getStackTrace in java
+func (e CloneNotSupportedException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/completion_exception.go
+++ b/java_exception/completion_exception.go
@@ -40,3 +40,8 @@ func (CompletionException) JavaClassName() string {
 func NewCompletionException(detailMessage string) *CompletionException {
 	return &CompletionException{DetailMessage: detailMessage}
 }
+
+// equals to getStackTrace in java
+func (e CompletionException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/concurrent_modification_exception.go
+++ b/java_exception/concurrent_modification_exception.go
@@ -40,3 +40,8 @@ func (ConcurrentModificationException) JavaClassName() string {
 func NewConcurrentModificationException(detailMessage string) *ConcurrentModificationException {
 	return &ConcurrentModificationException{DetailMessage: detailMessage}
 }
+
+// equals to getStackTrace in java
+func (e ConcurrentModificationException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/data_format_exception.go
+++ b/java_exception/data_format_exception.go
@@ -40,3 +40,8 @@ func (e DataFormatException) Error() string {
 func (DataFormatException) JavaClassName() string {
 	return "java.util.zip.DataFormatException"
 }
+
+// equals to getStackTrace in java
+func (e DataFormatException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/date_time_exception.go
+++ b/java_exception/date_time_exception.go
@@ -40,3 +40,8 @@ func (e DateTimeException) Error() string {
 func (DateTimeException) JavaClassName() string {
 	return "java.time.DateTimeException"
 }
+
+// equals to getStackTrace in java
+func (e DateTimeException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/date_time_parse_exception.go
+++ b/java_exception/date_time_parse_exception.go
@@ -42,3 +42,8 @@ func (e DateTimeParseException) Error() string {
 func (DateTimeParseException) JavaClassName() string {
 	return "java.time.format.DateTimeParseException"
 }
+
+// equals to getStackTrace in java
+func (e DateTimeParseException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/dubbo_generic_exception.go
+++ b/java_exception/dubbo_generic_exception.go
@@ -42,3 +42,8 @@ func (e DubboGenericException) Error() string {
 func (DubboGenericException) JavaClassName() string {
 	return "com.alibaba.dubbo.rpc.service.GenericException"
 }
+
+// equals to getStackTrace in java
+func (e DubboGenericException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/duplicate_format_flags_exception.go
+++ b/java_exception/duplicate_format_flags_exception.go
@@ -46,3 +46,8 @@ func (DuplicateFormatFlagsException) JavaClassName() string {
 func NewDuplicateFormatFlagsException(detailMessage string) *DuplicateFormatFlagsException {
 	return &DuplicateFormatFlagsException{DetailMessage: detailMessage}
 }
+
+// equals to getStackTrace in java
+func (e DuplicateFormatFlagsException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/empty_stack_exception.go
+++ b/java_exception/empty_stack_exception.go
@@ -40,3 +40,8 @@ func (EmptyStackException) JavaClassName() string {
 func NewEmptyStackException(detailMessage string) *EmptyStackException {
 	return &EmptyStackException{DetailMessage: detailMessage}
 }
+
+// equals to getStackTrace in java
+func (e EmptyStackException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/enum_constant_not_present_exception.go
+++ b/java_exception/enum_constant_not_present_exception.go
@@ -42,3 +42,8 @@ func (e EnumConstantNotPresentException) Error() string {
 func (EnumConstantNotPresentException) JavaClassName() string {
 	return "java.lang.EnumConstantNotPresentException"
 }
+
+// equals to getStackTrace in java
+func (e EnumConstantNotPresentException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/eof_exception.go
+++ b/java_exception/eof_exception.go
@@ -40,3 +40,8 @@ func (e EOFException) Error() string {
 func (EOFException) JavaClassName() string {
 	return "java.io.EOFException"
 }
+
+// equals to getStackTrace in java
+func (e EOFException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/exception.go
+++ b/java_exception/exception.go
@@ -25,6 +25,7 @@ package java_exception
 type Throwabler interface {
 	Error() string
 	JavaClassName() string
+	GetStackTrace() []StackTraceElement
 }
 
 ////////////////////////////
@@ -54,6 +55,11 @@ func (Throwable) JavaClassName() string {
 	return "java.lang.Throwable"
 }
 
+// equals to getStackTrace in java
+func (e Throwable) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}
+
 ////////////////////////////
 // Exception
 ////////////////////////////
@@ -77,6 +83,11 @@ func (e Exception) Error() string {
 //JavaClassName  java fully qualified path
 func (Exception) JavaClassName() string {
 	return "java.lang.Exception"
+}
+
+// equals to getStackTrace in java
+func (e Exception) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
 }
 
 ////////////////////////////

--- a/java_exception/execution_exception.go
+++ b/java_exception/execution_exception.go
@@ -40,3 +40,8 @@ func (e ExecutionException) Error() string {
 func (ExecutionException) JavaClassName() string {
 	return "java.util.concurrent.ExecutionException"
 }
+
+// equals to getStackTrace in java
+func (e ExecutionException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/file_not_found_exception.go
+++ b/java_exception/file_not_found_exception.go
@@ -40,3 +40,8 @@ func (e FileNotFoundException) Error() string {
 func (FileNotFoundException) JavaClassName() string {
 	return "java.io.FileNotFoundException"
 }
+
+// equals to getStackTrace in java
+func (e FileNotFoundException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/formatter_closed_exception.go
+++ b/java_exception/formatter_closed_exception.go
@@ -40,3 +40,8 @@ func (e FormatterClosedException) Error() string {
 func (FormatterClosedException) JavaClassName() string {
 	return "java.util.FormatterClosedException"
 }
+
+// equals to getStackTrace in java
+func (e FormatterClosedException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/illegal_access_exception.go
+++ b/java_exception/illegal_access_exception.go
@@ -40,3 +40,8 @@ func (e IllegalAccessException) Error() string {
 func (IllegalAccessException) JavaClassName() string {
 	return "java.lang.IllegalAccessException"
 }
+
+// equals to getStackTrace in java
+func (e IllegalAccessException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/illegal_argument_exception.go
+++ b/java_exception/illegal_argument_exception.go
@@ -40,3 +40,7 @@ func (e IllegalArgumentException) Error() string {
 func (IllegalArgumentException) JavaClassName() string {
 	return "java.lang.IllegalArgumentException"
 }
+// equals to getStackTrace in java
+func (e IllegalArgumentException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/illegal_classFormat_exception.go
+++ b/java_exception/illegal_classFormat_exception.go
@@ -40,3 +40,8 @@ func (e IllegalClassFormatException) Error() string {
 func (IllegalClassFormatException) JavaClassName() string {
 	return "java.lang.instrument.IllegalClassFormatException"
 }
+
+// equals to getStackTrace in java
+func (e IllegalClassFormatException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/illegal_format_code_point_exception.go
+++ b/java_exception/illegal_format_code_point_exception.go
@@ -43,3 +43,8 @@ func (e IllegalFormatCodePointException) Error() string {
 func (IllegalFormatCodePointException) JavaClassName() string {
 	return "java.util.IllegalFormatCodePointException"
 }
+
+// equals to getStackTrace in java
+func (e IllegalFormatCodePointException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/illegal_format_conversion_exception.go
+++ b/java_exception/illegal_format_conversion_exception.go
@@ -44,3 +44,8 @@ func (IllegalFormatConversionException) JavaClassName() string {
 func NewIllegalFormatConversionException(detailMessage string) *IllegalFormatConversionException {
 	return &IllegalFormatConversionException{DetailMessage: detailMessage}
 }
+
+// equals to getStackTrace in java
+func (e IllegalFormatConversionException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/illegal_format_flags_exception.go
+++ b/java_exception/illegal_format_flags_exception.go
@@ -43,3 +43,8 @@ func (e IllegalFormatFlagsException) Error() string {
 func (IllegalFormatFlagsException) JavaClassName() string {
 	return "java.util.IllegalFormatFlagsException"
 }
+
+// equals to getStackTrace in java
+func (e IllegalFormatFlagsException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/illegal_format_precision_exception.go
+++ b/java_exception/illegal_format_precision_exception.go
@@ -43,3 +43,8 @@ func (e IllegalFormatPrecisionException) Error() string {
 func (IllegalFormatPrecisionException) JavaClassName() string {
 	return "java.util.IllegalFormatPrecisionException"
 }
+
+// equals to getStackTrace in java
+func (e IllegalFormatPrecisionException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/illegal_format_width_exception.go
+++ b/java_exception/illegal_format_width_exception.go
@@ -43,3 +43,8 @@ func (IllegalFormatWidthException) JavaClassName() string {
 func NewIllegalFormatWidthException(w int) *IllegalFormatWidthException {
 	return &IllegalFormatWidthException{W: w}
 }
+
+// equals to getStackTrace in java
+func (e IllegalFormatWidthException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/illegal_monitor_state_exception.go
+++ b/java_exception/illegal_monitor_state_exception.go
@@ -40,3 +40,8 @@ func (e IllegalMonitorStateException) Error() string {
 func (IllegalMonitorStateException) JavaClassName() string {
 	return "java.lang.IllegalMonitorStateException"
 }
+
+// equals to getStackTrace in java
+func (e IllegalMonitorStateException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/illegal_state_exception.go
+++ b/java_exception/illegal_state_exception.go
@@ -40,3 +40,8 @@ func (e IllegalStateException) Error() string {
 func (IllegalStateException) JavaClassName() string {
 	return "java.lang.IllegalStateException"
 }
+
+// equals to getStackTrace in java
+func (e IllegalStateException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/illegal_thread_state_exception.go
+++ b/java_exception/illegal_thread_state_exception.go
@@ -40,3 +40,8 @@ func (e IllegalThreadStateException) Error() string {
 func (IllegalThreadStateException) JavaClassName() string {
 	return "java.lang.IllegalThreadStateException"
 }
+
+// equals to getStackTrace in java
+func (e IllegalThreadStateException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/illformed_locale_exception.go
+++ b/java_exception/illformed_locale_exception.go
@@ -41,3 +41,8 @@ func (IllformedLocaleException) JavaClassName() string {
 func NewIllformedLocaleException(detailMessage string) *IllformedLocaleException {
 	return &IllformedLocaleException{DetailMessage: detailMessage}
 }
+
+// equals to getStackTrace in java
+func (e IllformedLocaleException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/incomplete_annotation_exception.go
+++ b/java_exception/incomplete_annotation_exception.go
@@ -42,3 +42,8 @@ func (e IncompleteAnnotationException) Error() string {
 func (IncompleteAnnotationException) JavaClassName() string {
 	return "java.lang.annotation.IncompleteAnnotationException"
 }
+
+// equals to getStackTrace in java
+func (e IncompleteAnnotationException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/index_out_of_bounds_exception.go
+++ b/java_exception/index_out_of_bounds_exception.go
@@ -40,3 +40,8 @@ func (e IndexOutOfBoundsException) Error() string {
 func (IndexOutOfBoundsException) JavaClassName() string {
 	return "java.lang.IndexOutOfBoundsException"
 }
+
+// equals to getStackTrace in java
+func (e IndexOutOfBoundsException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/input_mismatch_exception.go
+++ b/java_exception/input_mismatch_exception.go
@@ -40,3 +40,8 @@ func (e InputMismatchException) Error() string {
 func (InputMismatchException) JavaClassName() string {
 	return "java.util.InputMismatchException"
 }
+
+// equals to getStackTrace in java
+func (e InputMismatchException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/instantiation_exception.go
+++ b/java_exception/instantiation_exception.go
@@ -40,3 +40,8 @@ func (e InstantiationException) Error() string {
 func (InstantiationException) JavaClassName() string {
 	return "java.lang.InstantiationException"
 }
+
+// equals to getStackTrace in java
+func (e InstantiationException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/interrupted_exception.go
+++ b/java_exception/interrupted_exception.go
@@ -43,3 +43,8 @@ func (e InterruptedException) Error() string {
 func (InterruptedException) JavaClassName() string {
 	return "java.lang.InterruptedException"
 }
+
+// equals to getStackTrace in java
+func (e InterruptedException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/interrupted_io_exception.go
+++ b/java_exception/interrupted_io_exception.go
@@ -44,3 +44,8 @@ func (e InterruptedIOException) Error() string {
 func (InterruptedIOException) JavaClassName() string {
 	return "java.io.InterruptedIOException"
 }
+
+// equals to getStackTrace in java
+func (e InterruptedIOException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/invalid_class_exception.go
+++ b/java_exception/invalid_class_exception.go
@@ -48,3 +48,8 @@ func (e InvalidClassException) Error() string {
 func (InvalidClassException) JavaClassName() string {
 	return "java.io.InvalidClassException"
 }
+
+// equals to getStackTrace in java
+func (e InvalidClassException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/invalid_object_exception.go
+++ b/java_exception/invalid_object_exception.go
@@ -40,3 +40,8 @@ func (e InvalidObjectException) Error() string {
 func (InvalidObjectException) JavaClassName() string {
 	return "java.io.InvalidObjectException"
 }
+
+// equals to getStackTrace in java
+func (e InvalidObjectException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/invalid_preferences_format_exception.go
+++ b/java_exception/invalid_preferences_format_exception.go
@@ -40,3 +40,8 @@ func (e InvalidPreferencesFormatException) Error() string {
 func (InvalidPreferencesFormatException) JavaClassName() string {
 	return "java.util.prefs.InvalidPreferencesFormatException"
 }
+
+// equals to getStackTrace in java
+func (e InvalidPreferencesFormatException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/invalid_properties_format_exception.go
+++ b/java_exception/invalid_properties_format_exception.go
@@ -40,3 +40,8 @@ func (e InvalidPropertiesFormatException) Error() string {
 func (InvalidPropertiesFormatException) JavaClassName() string {
 	return "java.util.InvalidPropertiesFormatException"
 }
+
+// equals to getStackTrace in java
+func (e InvalidPropertiesFormatException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/invocation_target_exception.go
+++ b/java_exception/invocation_target_exception.go
@@ -41,3 +41,8 @@ func (e InvocationTargetException) Error() string {
 func (InvocationTargetException) JavaClassName() string {
 	return "java.lang.reflect.InvocationTargetException"
 }
+
+// equals to getStackTrace in java
+func (e InvocationTargetException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/io_exception.go
+++ b/java_exception/io_exception.go
@@ -40,3 +40,8 @@ func (e IOException) Error() string {
 func (IOException) JavaClassName() string {
 	return "java.io.IOException"
 }
+
+// equals to getStackTrace in java
+func (e IOException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/jar_exception.go
+++ b/java_exception/jar_exception.go
@@ -40,3 +40,8 @@ func (e JarException) Error() string {
 func (JarException) JavaClassName() string {
 	return "java.util.jar.JarException"
 }
+
+// equals to getStackTrace in java
+func (e JarException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/lambda_conversion_exception.go
+++ b/java_exception/lambda_conversion_exception.go
@@ -43,3 +43,8 @@ func (e LambdaConversionException) Error() string {
 func (LambdaConversionException) JavaClassName() string {
 	return "java.lang.invoke.LambdaConversionException"
 }
+
+// equals to getStackTrace in java
+func (e LambdaConversionException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/malformed_parameterized_type_exception.go
+++ b/java_exception/malformed_parameterized_type_exception.go
@@ -40,3 +40,8 @@ func (MalformedParameterizedTypeException) JavaClassName() string {
 func NewMalformedParameterizedTypeException(detailMessage string) *MalformedParameterizedTypeException {
 	return &MalformedParameterizedTypeException{DetailMessage: detailMessage}
 }
+
+// equals to getStackTrace in java
+func (e MalformedParameterizedTypeException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/malformed_parameters_exception.go
+++ b/java_exception/malformed_parameters_exception.go
@@ -40,3 +40,8 @@ func (MalformedParametersException) JavaClassName() string {
 func NewMalformedParametersException(detailMessage string) *MalformedParametersException {
 	return &MalformedParametersException{DetailMessage: detailMessage}
 }
+
+// equals to getStackTrace in java
+func (e MalformedParametersException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/missing_format_argument_exception.go
+++ b/java_exception/missing_format_argument_exception.go
@@ -43,3 +43,8 @@ func (e MissingFormatArgumentException) Error() string {
 func (MissingFormatArgumentException) JavaClassName() string {
 	return "java.util.MissingFormatArgumentException"
 }
+
+// equals to getStackTrace in java
+func (e MissingFormatArgumentException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/missing_format_width_exception.go
+++ b/java_exception/missing_format_width_exception.go
@@ -41,3 +41,8 @@ func (e MissingFormatWidthException) Error() string {
 func (MissingFormatWidthException) JavaClassName() string {
 	return "java.util.MissingFormatWidthException"
 }
+
+// equals to getStackTrace in java
+func (e MissingFormatWidthException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/missing_resource_exception.go
+++ b/java_exception/missing_resource_exception.go
@@ -42,3 +42,8 @@ func (MissingResourceException) JavaClassName() string {
 func NewMissingResourceException(detailMessage, classname, key string) *MissingResourceException {
 	return &MissingResourceException{DetailMessage: detailMessage, ClassName: classname, Key: key}
 }
+
+// equals to getStackTrace in java
+func (e MissingResourceException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/negative_array_size_exception.go
+++ b/java_exception/negative_array_size_exception.go
@@ -40,3 +40,8 @@ func (e NegativeArraySizeException) Error() string {
 func (NegativeArraySizeException) JavaClassName() string {
 	return "java.lang.NegativeArraySizeException"
 }
+
+// equals to getStackTrace in java
+func (e NegativeArraySizeException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/no_such_element_exception.go
+++ b/java_exception/no_such_element_exception.go
@@ -40,3 +40,8 @@ func (NoSuchElementException) JavaClassName() string {
 func NewNoSuchElementException(detailMessage string) *NoSuchElementException {
 	return &NoSuchElementException{DetailMessage: detailMessage}
 }
+
+// equals to getStackTrace in java
+func (e NoSuchElementException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/no_such_field_exception.go
+++ b/java_exception/no_such_field_exception.go
@@ -40,3 +40,8 @@ func (e NoSuchFieldException) Error() string {
 func (NoSuchFieldException) JavaClassName() string {
 	return "java.lang.NoSuchFieldException"
 }
+
+// equals to getStackTrace in java
+func (e NoSuchFieldException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/no_such_method_exception.go
+++ b/java_exception/no_such_method_exception.go
@@ -40,3 +40,8 @@ func (e NoSuchMethodException) Error() string {
 func (NoSuchMethodException) JavaClassName() string {
 	return "java.lang.NoSuchMethodException"
 }
+
+// equals to getStackTrace in java
+func (e NoSuchMethodException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/not_active_exception.go
+++ b/java_exception/not_active_exception.go
@@ -40,3 +40,8 @@ func (e NotActiveException) Error() string {
 func (NotActiveException) JavaClassName() string {
 	return "java.io.NotActiveException"
 }
+
+// equals to getStackTrace in java
+func (e NotActiveException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/not_serializable_exception.go
+++ b/java_exception/not_serializable_exception.go
@@ -40,3 +40,8 @@ func (e NotSerializableException) Error() string {
 func (NotSerializableException) JavaClassName() string {
 	return "java.io.NotSerializableException"
 }
+
+// equals to getStackTrace in java
+func (e NotSerializableException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/null_pointer_exception.go
+++ b/java_exception/null_pointer_exception.go
@@ -40,3 +40,8 @@ func (e NullPointerException) Error() string {
 func (e NullPointerException) JavaClassName() string {
 	return "java.lang.NullPointerException"
 }
+
+// equals to getStackTrace in java
+func (e NullPointerException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/number_format_exception.go
+++ b/java_exception/number_format_exception.go
@@ -40,3 +40,8 @@ func (e NumberFormatException) Error() string {
 func (NumberFormatException) JavaClassName() string {
 	return "java.lang.NumberFormatException"
 }
+
+// equals to getStackTrace in java
+func (e NumberFormatException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/object_stream_exception.go
+++ b/java_exception/object_stream_exception.go
@@ -40,3 +40,8 @@ func (e ObjectStreamException) Error() string {
 func (ObjectStreamException) JavaClassName() string {
 	return "java.io.ObjectStreamException"
 }
+
+// equals to getStackTrace in java
+func (e ObjectStreamException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/optional_data_exception.go
+++ b/java_exception/optional_data_exception.go
@@ -42,3 +42,8 @@ func (e OptionalDataException) Error() string {
 func (OptionalDataException) JavaClassName() string {
 	return "java.io.OptionalDataException"
 }
+
+// equals to getStackTrace in java
+func (e OptionalDataException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/reflective_operation_exception.go
+++ b/java_exception/reflective_operation_exception.go
@@ -40,3 +40,8 @@ func (e ReflectiveOperationException) Error() string {
 func (ReflectiveOperationException) JavaClassName() string {
 	return "java.lang.ReflectiveOperationException"
 }
+
+// equals to getStackTrace in java
+func (e ReflectiveOperationException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/rejected_execution_exception.go
+++ b/java_exception/rejected_execution_exception.go
@@ -40,3 +40,8 @@ func (RejectedExecutionException) JavaClassName() string {
 func NewRejectedExecutionException(detailMessage string) *RejectedExecutionException {
 	return &RejectedExecutionException{DetailMessage: detailMessage}
 }
+
+// equals to getStackTrace in java
+func (e RejectedExecutionException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/runtime_exception.go
+++ b/java_exception/runtime_exception.go
@@ -40,3 +40,8 @@ func (e RuntimeException) Error() string {
 func (RuntimeException) JavaClassName() string {
 	return "java.lang.RuntimeException"
 }
+
+// equals to getStackTrace in java
+func (e RuntimeException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/security_exception.go
+++ b/java_exception/security_exception.go
@@ -40,3 +40,8 @@ func (e SecurityException) Error() string {
 func (SecurityException) JavaClassName() string {
 	return "java.lang.SecurityException"
 }
+
+// equals to getStackTrace in java
+func (e SecurityException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/stream_corrupted_exception.go
+++ b/java_exception/stream_corrupted_exception.go
@@ -40,3 +40,8 @@ func (e StreamCorruptedException) Error() string {
 func (StreamCorruptedException) JavaClassName() string {
 	return "java.io.StreamCorruptedException"
 }
+
+// equals to getStackTrace in java
+func (e StreamCorruptedException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/string_index_out_of_bounds_exception.go
+++ b/java_exception/string_index_out_of_bounds_exception.go
@@ -40,3 +40,8 @@ func (e StringIndexOutOfBoundsException) Error() string {
 func (StringIndexOutOfBoundsException) JavaClassName() string {
 	return "java.lang.StringIndexOutOfBoundsException"
 }
+
+// equals to getStackTrace in java
+func (e StringIndexOutOfBoundsException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/sync_failed_exception.go
+++ b/java_exception/sync_failed_exception.go
@@ -40,3 +40,8 @@ func (e SyncFailedException) Error() string {
 func (SyncFailedException) JavaClassName() string {
 	return "java.io.SyncFailedException"
 }
+
+// equals to getStackTrace in java
+func (e SyncFailedException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/timeout_exception.go
+++ b/java_exception/timeout_exception.go
@@ -40,3 +40,8 @@ func (e TimeoutException) Error() string {
 func (TimeoutException) JavaClassName() string {
 	return "java.util.concurrent.TimeoutException"
 }
+
+// equals to getStackTrace in java
+func (e TimeoutException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/too_many_listeners_exception.go
+++ b/java_exception/too_many_listeners_exception.go
@@ -40,3 +40,8 @@ func (e TooManyListenersException) Error() string {
 func (TooManyListenersException) JavaClassName() string {
 	return "java.util.TooManyListenersException"
 }
+
+// equals to getStackTrace in java
+func (e TooManyListenersException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/type_not_present_exception.go
+++ b/java_exception/type_not_present_exception.go
@@ -41,3 +41,8 @@ func (TypeNotPresentException) JavaClassName() string {
 func NewTypeNotPresentException(typeName string, detailMessage string) *TypeNotPresentException {
 	return &TypeNotPresentException{TypeName: typeName, DetailMessage: detailMessage}
 }
+
+// equals to getStackTrace in java
+func (e TypeNotPresentException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/unchecked_IO_exception.go
+++ b/java_exception/unchecked_IO_exception.go
@@ -44,3 +44,8 @@ func (e UncheckedIOException) Error() string {
 func (UncheckedIOException) JavaClassName() string {
 	return "java.io.UncheckedIOException"
 }
+
+// equals to getStackTrace in java
+func (e UncheckedIOException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/undeclared_throwable_exception.go
+++ b/java_exception/undeclared_throwable_exception.go
@@ -41,3 +41,8 @@ func (UndeclaredThrowableException) JavaClassName() string {
 func NewUndeclaredThrowableException(detailMessage string) *UndeclaredThrowableException {
 	return &UndeclaredThrowableException{DetailMessage: detailMessage, UndeclaredThrowable: Throwable{}}
 }
+
+// equals to getStackTrace in java
+func (e UndeclaredThrowableException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/unknown_format_conversion_exception.go
+++ b/java_exception/unknown_format_conversion_exception.go
@@ -43,3 +43,8 @@ func (e UnknownFormatConversionException) Error() string {
 func (UnknownFormatConversionException) JavaClassName() string {
 	return "java.util.UnknownFormatConversionException"
 }
+
+// equals to getStackTrace in java
+func (e UnknownFormatConversionException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/unknown_format_flags_exception.go
+++ b/java_exception/unknown_format_flags_exception.go
@@ -41,3 +41,8 @@ func (e UnknownFormatFlagsException) Error() string {
 func (UnknownFormatFlagsException) JavaClassName() string {
 	return "java.util.UnknownFormatFlagsException"
 }
+
+// equals to getStackTrace in java
+func (e UnknownFormatFlagsException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/unmodifiable_class_exception.go
+++ b/java_exception/unmodifiable_class_exception.go
@@ -43,3 +43,8 @@ func (e UnmodifiableClassException) Error() string {
 func (UnmodifiableClassException) JavaClassName() string {
 	return "java.lang.instrument.UnmodifiableClassException"
 }
+
+// equals to getStackTrace in java
+func (e UnmodifiableClassException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/unsupported_operation_exception.go
+++ b/java_exception/unsupported_operation_exception.go
@@ -40,3 +40,8 @@ func (e UnsupportedOperationException) Error() string {
 func (UnsupportedOperationException) JavaClassName() string {
 	return "java.lang.UnsupportedOperationException"
 }
+
+// equals to getStackTrace in java
+func (e UnsupportedOperationException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/unsupported_temporal_type_exception.go
+++ b/java_exception/unsupported_temporal_type_exception.go
@@ -40,3 +40,8 @@ func (e UnsupportedTemporalTypeException) Error() string {
 func (UnsupportedTemporalTypeException) JavaClassName() string {
 	return "java.time.temporal.UnsupportedTemporalTypeException"
 }
+
+// equals to getStackTrace in java
+func (e UnsupportedTemporalTypeException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/utf_data_format_exception.go
+++ b/java_exception/utf_data_format_exception.go
@@ -40,3 +40,8 @@ func (e UTFDataFormatException) Error() string {
 func (UTFDataFormatException) JavaClassName() string {
 	return "java.io.UTFDataFormatException"
 }
+
+// equals to getStackTrace in java
+func (e UTFDataFormatException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/write_aborted_exception.go
+++ b/java_exception/write_aborted_exception.go
@@ -42,3 +42,8 @@ func (e WriteAbortedException) Error() string {
 func (WriteAbortedException) JavaClassName() string {
 	return "java.io.WriteAbortedException"
 }
+
+// equals to getStackTrace in java
+func (e WriteAbortedException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/wrong_method_type_exception.go
+++ b/java_exception/wrong_method_type_exception.go
@@ -40,3 +40,8 @@ func (WrongMethodTypeException) JavaClassName() string {
 func NewWrongMethodTypeException(detailMessage string) *WrongMethodTypeException {
 	return &WrongMethodTypeException{DetailMessage: detailMessage}
 }
+
+// equals to getStackTrace in java
+func (e WrongMethodTypeException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/zip_exception.go
+++ b/java_exception/zip_exception.go
@@ -40,3 +40,8 @@ func (e ZipException) Error() string {
 func (ZipException) JavaClassName() string {
 	return "java.util.zip.ZipException"
 }
+
+// equals to getStackTrace in java
+func (e ZipException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}

--- a/java_exception/zone_rules_exception.go
+++ b/java_exception/zone_rules_exception.go
@@ -40,3 +40,8 @@ func (e ZoneRulesException) Error() string {
 func (ZoneRulesException) JavaClassName() string {
 	return "java.time.zone.ZoneRulesException"
 }
+
+// equals to getStackTrace in java
+func (e ZoneRulesException) GetStackTrace() []StackTraceElement {
+	return e.StackTrace
+}


### PR DESCRIPTION
go语言client请求java语言服务时，如果java语言抛出了异常，异常对应的堆栈信息是被保存在StackTraceElement中。

这个异常信息在日志中最好能被打印出来，以方便客户端排查问题，所以在Throwabler和对应子类中增加了StackTraceElement的获取。

注：其实还有一种更好的方法，所有的具体的异常类型都包含java_exception/exception.go的Throwable struct。这样只需要在Throwable中增加GetStackTrace方法就可以了。但是这种方式需要更多的测试验证，改动的逻辑相对会复杂一些。但是代码会更整洁。 这里先不用这种方法。