### PR TITLE
java.sql.Time & java.sql.Date

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -76,7 +76,7 @@ func getJavaReply(method, className string) []byte {
 	if className != "" {
 		cmdArgs = append(cmdArgs, className)
 	}
-	cmd := exec.Command("/Library/Java/JavaVirtualMachines/jdk1.8.0_201.jdk/Contents/Home/bin/java", cmdArgs...)
+	cmd := exec.Command("java", cmdArgs...)
 	out, err := cmd.Output()
 	if err != nil {
 		log.Fatal(err)

--- a/decode_test.go
+++ b/decode_test.go
@@ -76,7 +76,7 @@ func getJavaReply(method, className string) []byte {
 	if className != "" {
 		cmdArgs = append(cmdArgs, className)
 	}
-	cmd := exec.Command("java", cmdArgs...)
+	cmd := exec.Command("/Library/Java/JavaVirtualMachines/jdk1.8.0_201.jdk/Contents/Home/bin/java", cmdArgs...)
 	out, err := cmd.Output()
 	if err != nil {
 		log.Fatal(err)

--- a/java_sql_time.go
+++ b/java_sql_time.go
@@ -33,21 +33,14 @@ import (
 func init() {
 	RegisterPOJO(&java_sql_time.Date{})
 	RegisterPOJO(&java_sql_time.Time{})
+	SetJavaSqlTimeSerialize(&java_sql_time.Date{})
+	SetJavaSqlTimeSerialize(&java_sql_time.Time{})
 }
-
-var javaSqlTimeTypeMap = make(map[string]reflect.Type, 16)
 
 // SetJavaSqlTimeSerialize register serializer for java.sql.Time & java.sql.Date
 func SetJavaSqlTimeSerialize(time java_sql_time.JavaSqlTime) {
 	name := time.JavaClassName()
-	var typ = reflect.TypeOf(time)
 	SetSerializer(name, JavaSqlTimeSerializer{})
-	javaSqlTimeTypeMap[name] = typ
-}
-
-// nolint
-func getJavaSqlTimeSerialize(name string) reflect.Type {
-	return javaSqlTimeTypeMap[name]
 }
 
 // JavaSqlTimeSerializer used to encode & decode java.sql.Time & java.sql.Date
@@ -144,9 +137,9 @@ func (JavaSqlTimeSerializer) DecObject(d *Decoder, typ reflect.Type, cls classIn
 	sqlTime := vRef.Interface()
 
 	result, ok := sqlTime.(java_sql_time.JavaSqlTime)
-	result.SetTime(date)
 	if !ok {
 		panic("result type is not sql time, please check the whether the conversion is ok")
 	}
+	result.SetTime(date)
 	return result, nil
 }

--- a/java_sql_time.go
+++ b/java_sql_time.go
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hessian
+
+import (
+	"reflect"
+	"time"
+)
+
+import (
+	perrors "github.com/pkg/errors"
+)
+
+type JavaSqlTime interface {
+	SetTime(time int64)
+	ValueOf(time string) (JavaSqlTime, error)
+	JavaClassName() string
+	UnixNano() int64
+	time() time.Time
+}
+type Date struct {
+	time.Time
+}
+
+func (d Date) time() time.Time {
+	return d.Time
+}
+
+func (Date) JavaClassName() string {
+	return "java.sql.Date"
+}
+
+func (Date) Error() string {
+	return "encode java.sql.Date error"
+}
+func (Date) SetTime(time int64) {
+	panic("")
+}
+func (Date) ValueOf(time string) (JavaSqlTime, error) {
+	panic("")
+}
+
+type Time struct {
+	time.Time
+}
+
+func (Time) JavaClassName() string {
+	return "java.sql.Time"
+}
+
+func (Time) Error() string {
+	return "encode java.sql.Time error"
+}
+
+func (t Time) time() time.Time {
+	return t.Time
+}
+
+func (Time) SetTime(time int64) {
+	panic("")
+}
+func (Time) ValueOf(time string) (JavaSqlTime, error) {
+	panic("")
+}
+
+var javaSqlTimeTypeMap = make(map[string]reflect.Type, 16)
+
+func SetJavaSqlTimeSerialize(time JavaSqlTime) {
+	name := time.JavaClassName()
+	v := reflect.ValueOf(time)
+	var typ reflect.Type
+	switch v.Kind() {
+	case reflect.Struct:
+		typ = v.Type()
+	case reflect.Ptr:
+		typ = v.Elem().Type()
+	default:
+		typ = reflect.TypeOf(time)
+	}
+	SetSerializer(name, JavaSqlTimeSerializer{})
+	//RegisterPOJO(time)
+	javaSqlTimeTypeMap[name] = typ
+}
+
+func getJavaSqlTimeSerialize(name string) reflect.Type {
+	return javaSqlTimeTypeMap[name]
+}
+
+type JavaSqlTimeSerializer struct {
+}
+
+func (JavaSqlTimeSerializer) EncObject(e *Encoder, vv POJO) error {
+
+	var (
+		idx    int
+		idx1   int
+		i      int
+		err    error
+		clsDef classInfo
+	)
+	v, ok := vv.(JavaSqlTime)
+	if !ok {
+		return perrors.New("can not be converted into java sql time object")
+	}
+	className := v.JavaClassName()
+	if className == "" {
+		return perrors.New("class name empty")
+	}
+
+	tValue := reflect.ValueOf(vv)
+	// check ref
+	if n, ok := e.checkRefMap(tValue); ok {
+		e.buffer = encRef(e.buffer, n)
+		return nil
+	}
+
+	// write object definition
+	idx = -1
+	for i = range e.classInfoList {
+		if v.JavaClassName() == e.classInfoList[i].javaName {
+			idx = i
+			break
+		}
+	}
+
+	if idx == -1 {
+		idx1, ok = checkPOJORegistry(typeof(v))
+		if !ok {
+			if reflect.TypeOf(v).Implements(javaEnumType) {
+				idx1 = RegisterJavaEnum(v.(POJOEnum))
+			} else {
+				idx1 = RegisterPOJO(v)
+			}
+		}
+		_, clsDef, err = getStructDefByIndex(idx1)
+		if err != nil {
+			return perrors.WithStack(err)
+		}
+
+		i = len(e.classInfoList)
+		e.classInfoList = append(e.classInfoList, clsDef)
+		e.buffer = append(e.buffer, clsDef.buffer...)
+		e.buffer = e.buffer[0 : len(e.buffer)-1]
+	}
+
+	//if idx < -1 {
+	//	e.buffer = encString(e.buffer, "value")
+	//	var bytes []byte
+	//	bytes = append(bytes, PackInt64(v.UnixNano()/1e6)...)
+	//	e.buffer = encDateInMs(bytes, v)
+	//	e.buffer = append(e.buffer, BC_END)
+	//} else
+	//{
+	if idx == -1 {
+		e.buffer = encInt32(e.buffer, 1)
+		e.buffer = encString(e.buffer, "value")
+
+		// write object instance
+		if byte(i) <= OBJECT_DIRECT_MAX {
+			e.buffer = encByte(e.buffer, byte(i)+BC_OBJECT_DIRECT)
+		} else {
+			e.buffer = encByte(e.buffer, BC_OBJECT)
+			e.buffer = encInt32(e.buffer, int32(idx1))
+		}
+		//if (ref == -1) {
+		//	out.writeInt(1);
+		//	out.writeString("value");
+		//	out.writeObjectBegin(cl.getName());
+		//}
+		//}
+		//var bytes []byte
+		//bytes = append(bytes, PackInt64(v.UnixNano()/1e6)...)
+		e.buffer = encDateInMs(e.buffer, v.time())
+	}
+
+	return nil
+}
+
+func (JavaSqlTimeSerializer) DecObject(d *Decoder, typ reflect.Type, cls classInfo) (interface{}, error) {
+
+	return nil, perrors.New("unexpected collection decode call")
+}

--- a/java_sql_time/date.go
+++ b/java_sql_time/date.go
@@ -1,0 +1,43 @@
+package java_sql_time
+
+import "time"
+
+type Date struct {
+	time.Time
+}
+
+func (d *Date) GetTime() time.Time {
+	return d.Time
+}
+
+func (d *Date) SetTime(time time.Time) {
+	d.Time = time
+}
+
+func (Date) JavaClassName() string {
+	return "java.sql.Date"
+}
+
+func (d *Date) ValueOf(dateStr string) error {
+	time, err := time.Parse("2006-01-02", dateStr)
+	if err != nil {
+		return err
+	}
+	d.Time = time
+	return nil
+}
+
+// nolint
+func (d *Date) Year() int {
+	return d.Time.Year()
+}
+
+// nolint
+func (d *Date) Month() time.Month {
+	return d.Time.Month()
+}
+
+// nolint
+func (d *Date) Day() int {
+	return d.Time.Day()
+}

--- a/java_sql_time/date.go
+++ b/java_sql_time/date.go
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package java_sql_time
 
 import "time"

--- a/java_sql_time/java_sql_time.go
+++ b/java_sql_time/java_sql_time.go
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package java_sql_time
 
 import "time"

--- a/java_sql_time/java_sql_time.go
+++ b/java_sql_time/java_sql_time.go
@@ -1,0 +1,13 @@
+package java_sql_time
+
+import "time"
+
+type JavaSqlTime interface {
+	// ValueOf parse time string which format likes '2006-01-02 15:04:05'
+	ValueOf(timeStr string) error
+	// SetTime for decode time
+	SetTime(time time.Time)
+	JavaClassName() string
+	// GetTime used to time
+	GetTime() time.Time
+}

--- a/java_sql_time/time.go
+++ b/java_sql_time/time.go
@@ -1,0 +1,43 @@
+package java_sql_time
+
+import "time"
+
+type Time struct {
+	time.Time
+}
+
+func (Time) JavaClassName() string {
+	return "java.sql.Time"
+}
+
+func (t *Time) GetTime() time.Time {
+	return t.Time
+}
+
+// nolint
+func (t *Time) Hour() int {
+	return t.Time.Hour()
+}
+
+// nolint
+func (t *Time) Minute() int {
+	return t.Time.Minute()
+}
+
+// nolint
+func (t *Time) Second() int {
+	return t.Time.Second()
+}
+
+func (t *Time) SetTime(time time.Time) {
+	t.Time = time
+}
+
+func (t *Time) ValueOf(timeStr string) error {
+	time, err := time.Parse("15:04:05", timeStr)
+	if err != nil {
+		return err
+	}
+	t.Time = time
+	return nil
+}

--- a/java_sql_time/time.go
+++ b/java_sql_time/time.go
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package java_sql_time
 
 import "time"

--- a/java_sql_time_test.go
+++ b/java_sql_time_test.go
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hessian
+
+import (
+	"testing"
+	"time"
+)
+
+func init() {
+	SetJavaSqlTimeSerialize(&Date{})
+	SetJavaSqlTimeSerialize(&Time{})
+}
+func TestJavaSqlTimeEncode(t *testing.T) {
+	Bdate := "1997-01-01 13:15:46"
+	location, _ := time.ParseInLocation("2006-01-02 15:04:05", Bdate, time.Local)
+	time1 := Time{Time: location}
+	t.Log(time1.UnixNano() / 1000000)
+	testJavaDecode(t, "javaSql_encode_time", time1)
+}

--- a/java_sql_time_test.go
+++ b/java_sql_time_test.go
@@ -26,9 +26,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+import (
+	"github.com/apache/dubbo-go-hessian2/java_sql_time"
+)
+
 func init() {
-	SetJavaSqlTimeSerialize(&Date{})
-	SetJavaSqlTimeSerialize(&Time{})
+	SetJavaSqlTimeSerialize(&java_sql_time.Date{})
+	SetJavaSqlTimeSerialize(&java_sql_time.Time{})
 }
 
 // test local time between go and java
@@ -36,11 +40,11 @@ func init() {
 // java decode
 func TestJavaSqlTimeEncode(t *testing.T) {
 	sqlTime := time.Date(1997, 1, 1, 13, 15, 46, 0, time.UTC)
-	testSqlTime := Time{Time: sqlTime}
+	testSqlTime := java_sql_time.Time{Time: sqlTime}
 	testJavaDecode(t, "javaSql_encode_time", testSqlTime)
 
 	sqlDate := time.Date(2020, 8, 9, 0, 0, 0, 0, time.UTC)
-	testSqlDate := Date{Time: sqlDate}
+	testSqlDate := java_sql_time.Date{Time: sqlDate}
 	testJavaDecode(t, "javaSql_encode_date", &testSqlDate)
 }
 
@@ -49,25 +53,25 @@ func TestJavaSqlTimeEncode(t *testing.T) {
 // go decode
 func TestJavaSqlTimeDecode(t *testing.T) {
 	sqlTime := time.Date(1997, 1, 1, 13, 15, 46, 0, time.UTC)
-	testSqlTime := Time{Time: sqlTime}
+	testSqlTime := java_sql_time.Time{Time: sqlTime}
 	testDecodeJavaSqlTime(t, "javaSql_decode_time", &testSqlTime)
 
 	sqlDate := time.Date(2020, 8, 9, 0, 0, 0, 0, time.UTC)
-	testDateTime := Date{Time: sqlDate}
+	testDateTime := java_sql_time.Date{Time: sqlDate}
 	testDecodeJavaSqlTime(t, "javaSql_decode_date", &testDateTime)
 }
 
-func testDecodeJavaSqlTime(t *testing.T, method string, expected JavaSqlTime) {
+func testDecodeJavaSqlTime(t *testing.T, method string, expected java_sql_time.JavaSqlTime) {
 	r, e := decodeJavaResponse(method, "", false)
 	if e != nil {
 		t.Errorf("%s: decode fail with error %v", method, e)
 		return
 	}
-	resultSqlTime, ok := r.(JavaSqlTime)
+	resultSqlTime, ok := r.(java_sql_time.JavaSqlTime)
 	if !ok {
 		t.Errorf("got error type:%v", r)
 	}
-	assert.Equal(t, resultSqlTime.time().UnixNano(), expected.time().UnixNano())
+	assert.Equal(t, resultSqlTime.GetTime().UnixNano(), expected.GetTime().UnixNano())
 }
 
 // test local time between go and go
@@ -75,7 +79,7 @@ func testDecodeJavaSqlTime(t *testing.T, method string, expected JavaSqlTime) {
 // go decode
 func TestJavaSqlTimeWithGo(t *testing.T) {
 	location, _ := time.ParseInLocation("2006-01-02 15:04:05", "1997-01-01 13:15:46", time.Local)
-	sqlTime := Time{Time: location}
+	sqlTime := java_sql_time.Time{Time: location}
 	e := NewEncoder()
 	e.Encode(&sqlTime)
 	if len(e.Buffer()) == 0 {
@@ -86,7 +90,7 @@ func TestJavaSqlTimeWithGo(t *testing.T) {
 	assert.Equal(t, &sqlTime, resultSqlTime)
 
 	location, _ = time.ParseInLocation("2006-01-02 15:04:05", "2020-08-09 00:00:00", time.Local)
-	sqlDate := Date{Time: location}
+	sqlDate := java_sql_time.Date{Time: location}
 	e = NewEncoder()
 	e.Encode(&sqlDate)
 	if len(e.Buffer()) == 0 {

--- a/java_sql_time_test.go
+++ b/java_sql_time_test.go
@@ -32,12 +32,12 @@ func init() {
 // go encode
 // java decode
 func TestJavaSqlTimeEncode(t *testing.T) {
-	location, _ := time.ParseInLocation("2006-01-02 15:04:05", "1997-01-01 13:15:46", time.Local)
-	testSqlTime := Time{Time: location}
+	sqlTime := time.Date(1997, 1, 1, 13, 15, 46, 0, time.UTC)
+	testSqlTime := Time{Time: sqlTime}
 	testJavaDecode(t, "javaSql_encode_time", &testSqlTime)
 
-	location, _ = time.ParseInLocation("2006-01-02 15:04:05", "2020-08-09 00:00:00", time.Local)
-	testSqlDate := Time{Time: location}
+	sqlDate := time.Date(2020, 8, 9, 0, 0, 0, 0, time.UTC)
+	testSqlDate := Date{Time: sqlDate}
 	testJavaDecode(t, "javaSql_encode_date", &testSqlDate)
 }
 
@@ -45,13 +45,28 @@ func TestJavaSqlTimeEncode(t *testing.T) {
 // java encode
 // go decode
 func TestJavaSqlTimeDecode(t *testing.T) {
-	location, _ := time.ParseInLocation("2006-01-02 15:04:05", "1997-01-01 13:15:46", time.Local)
-	testSqlTime := Time{Time: location}
-	testDecodeFramework(t, "javaSql_decode_time", &testSqlTime)
+	sqlTime := time.Date(1997, 1, 1, 13, 15, 46, 0, time.UTC)
+	testSqlTime := Time{Time: sqlTime}
+	testDecodeJavaSqlTime(t, "javaSql_decode_time", &testSqlTime)
 
-	location, _ = time.ParseInLocation("2006-01-02 15:04:05", "2020-08-09 00:00:00", time.Local)
-	testDateTime := Date{Time: location}
-	testDecodeFramework(t, "javaSql_decode_date", &testDateTime)
+	sqlDate := time.Date(2020, 8, 9, 0, 0, 0, 0, time.UTC)
+	testDateTime := Date{Time: sqlDate}
+	testDecodeJavaSqlTime(t, "javaSql_decode_date", &testDateTime)
+}
+
+func testDecodeJavaSqlTime(t *testing.T, method string, expected JavaSqlTime) {
+	r, e := decodeJavaResponse(method, "", false)
+	if e != nil {
+		t.Errorf("%s: decode fail with error %v", method, e)
+		return
+	}
+
+	resultSqlTime, ok := r.(JavaSqlTime)
+
+	if !ok {
+		t.Errorf("got error type:%v", r)
+	}
+	assert.Equal(t, resultSqlTime.time().UnixNano(), expected.time().UnixNano())
 }
 
 // test local time between go and go

--- a/java_sql_time_test.go
+++ b/java_sql_time_test.go
@@ -18,6 +18,7 @@
 package hessian
 
 import (
+	"reflect"
 	"testing"
 	"time"
 )
@@ -32,4 +33,23 @@ func TestJavaSqlTimeEncode(t *testing.T) {
 	time1 := Time{Time: location}
 	t.Log(time1.UnixNano() / 1000000)
 	testJavaDecode(t, "javaSql_encode_time", time1)
+}
+
+func TestJavaSqlTimeDecode(t *testing.T) {
+	Bdate := "1997-01-01 13:15:46"
+	location, _ := time.ParseInLocation("2006-01-02 15:04:05", Bdate, time.Local)
+	time1 := Time{Time: location}
+	//t.Log(time1.UnixNano() / 1000000)
+	//testJavaDecode(t, "javaSql_encode_time", time1)
+	testDecodeFramework(t, "javaSql_decode_time", &time1)
+}
+
+func TestName(t *testing.T) {
+	Bdate := "1997-01-01 13:15:46"
+	location, _ := time.ParseInLocation("2006-01-02 15:04:05", Bdate, time.Local)
+	time1 := Time{Time: location}
+	time2 := Time{Time: location}
+	r := time1
+	expected := time2
+	t.Log(reflect.DeepEqual(r, expected))
 }

--- a/java_sql_time_test.go
+++ b/java_sql_time_test.go
@@ -18,9 +18,12 @@
 package hessian
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
 )
 
 func init() {
@@ -34,7 +37,7 @@ func init() {
 func TestJavaSqlTimeEncode(t *testing.T) {
 	sqlTime := time.Date(1997, 1, 1, 13, 15, 46, 0, time.UTC)
 	testSqlTime := Time{Time: sqlTime}
-	testJavaDecode(t, "javaSql_encode_time", &testSqlTime)
+	testJavaDecode(t, "javaSql_encode_time", testSqlTime)
 
 	sqlDate := time.Date(2020, 8, 9, 0, 0, 0, 0, time.UTC)
 	testSqlDate := Date{Time: sqlDate}
@@ -60,9 +63,7 @@ func testDecodeJavaSqlTime(t *testing.T, method string, expected JavaSqlTime) {
 		t.Errorf("%s: decode fail with error %v", method, e)
 		return
 	}
-
 	resultSqlTime, ok := r.(JavaSqlTime)
-
 	if !ok {
 		t.Errorf("got error type:%v", r)
 	}

--- a/test_hessian/src/main/java/test/Hessian.java
+++ b/test_hessian/src/main/java/test/Hessian.java
@@ -82,7 +82,7 @@ public class Hessian {
                 System.out.print(method.invoke(testJavaSqlTime, o));
             } else {
                 Method method = TestJavaSqlTime.class.getMethod(args[0]);
-                TestJavaSqlTime testJavaSqlTime = new TestJavaSqlTime(System.out);
+                TestJavaSqlTime testJavaSqlTime = new TestJavaSqlTime();
                 Object object = method.invoke(testJavaSqlTime);
 
                 Hessian2Output output = new Hessian2Output(System.out);

--- a/test_hessian/src/main/java/test/Hessian.java
+++ b/test_hessian/src/main/java/test/Hessian.java
@@ -62,15 +62,34 @@ public class Hessian {
             Hessian2Output output = new Hessian2Output(System.out);
             output.writeObject(object);
             output.flush();
-        }else if(args[0].startsWith("java8_")){
+        } else if (args[0].startsWith("java8_")) {
             //add java8 java.time Object test
             Method method = TestJava8Time.class.getMethod(args[0]);
             Object obj = new Object();
-            Object object =method.invoke(obj);
+            Object object = method.invoke(obj);
 
             Hessian2Output output = new Hessian2Output(System.out);
             output.writeObject(object);
             output.flush();
+        } else if (args[0].startsWith("javaSql_")) {
+            if (args[0].startsWith("javaSql_encode")) {
+
+                Hessian2Input input = new Hessian2Input(System.in);
+                Object o = input.readObject();
+
+                Method method = TestJavaSqlTime.class.getMethod(args[0], Object.class);
+                TestJavaSqlTime testJavaSqlTime = new TestJavaSqlTime();
+                System.out.print(method.invoke(testJavaSqlTime, o));
+            } else {
+                Method method = TestJavaSqlTime.class.getMethod(args[0]);
+                TestJavaSqlTime testJavaSqlTime = new TestJavaSqlTime(System.out);
+                Object object = method.invoke(testJavaSqlTime);
+
+                Hessian2Output output = new Hessian2Output(System.out);
+                output.writeObject(object);
+                output.flush();
+            }
+
         }
     }
 

--- a/test_hessian/src/main/java/test/TestJavaSqlTime.java
+++ b/test_hessian/src/main/java/test/TestJavaSqlTime.java
@@ -17,32 +17,21 @@
 
 package test;
 
-import com.alibaba.com.caucho.hessian.io.Hessian2Output;
-
 import java.io.IOException;
-import java.io.OutputStream;
 import java.sql.Date;
 import java.sql.Time;
 import java.text.SimpleDateFormat;
 
 public class TestJavaSqlTime {
 
-    public void javaSql_decode_date() throws IOException {
+    public Object javaSql_decode_date() throws IOException {
         Date date = Date.valueOf("2020-08-09");
-        output.writeObject(date);
-        output.flush();
+        return date;
     }
 
-    public void javaSql_decode_time() throws IOException {
-        Time time = Time.valueOf("07:35:13");
-        output.writeObject(time);
-        output.flush();
-    }
-
-    private Hessian2Output output;
-
-    public TestJavaSqlTime(OutputStream os) {
-        output = new Hessian2Output(os);
+    public Object javaSql_decode_time() throws IOException {
+        Time time = new Time(852095746000L);
+        return time;
     }
 
 

--- a/test_hessian/src/main/java/test/TestJavaSqlTime.java
+++ b/test_hessian/src/main/java/test/TestJavaSqlTime.java
@@ -23,13 +23,11 @@ import java.sql.Time;
 public class TestJavaSqlTime {
 
     public Object javaSql_decode_date() {
-        Date date = Date.valueOf("2020-08-09");
-        return date;
+        return new Date(1596931200000L);
     }
 
     public Object javaSql_decode_time() {
-        Time time = new Time(852095746000L);
-        return time;
+        return new Time(852124546000L);
     }
 
 
@@ -37,12 +35,11 @@ public class TestJavaSqlTime {
     }
 
     public static Object javaSql_encode_time(Object v) {
-        return v.equals(new Time(852095746000L));
+        return v.equals(new Time(852124546000L));
     }
 
     public boolean javaSql_encode_date(Object v) {
-        Date date = Date.valueOf("2020-08-09");
-        return date.equals(v);
+        return v.equals(new Date(1596931200000L));
     }
 
 }

--- a/test_hessian/src/main/java/test/TestJavaSqlTime.java
+++ b/test_hessian/src/main/java/test/TestJavaSqlTime.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test;
+
+import com.alibaba.com.caucho.hessian.io.Hessian2Output;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.sql.Date;
+import java.sql.Time;
+import java.text.SimpleDateFormat;
+
+public class TestJavaSqlTime {
+
+    public void javaSql_decode_date() throws IOException {
+        Date date = Date.valueOf("2020-08-09");
+        output.writeObject(date);
+        output.flush();
+    }
+
+    public void javaSql_decode_time() throws IOException {
+        Time time = Time.valueOf("07:35:13");
+        output.writeObject(time);
+        output.flush();
+    }
+
+    private Hessian2Output output;
+
+    public TestJavaSqlTime(OutputStream os) {
+        output = new Hessian2Output(os);
+    }
+
+
+    public TestJavaSqlTime() {
+    }
+
+    public static void main(String[] args) {
+        long time = 894621091000L;
+
+        time -= time % 60000L;
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        System.out.println(sdf.format(new java.util.Date(time)));
+    }
+
+    public static Object javaSql_encode_time(Object v) {
+        return v.equals(new Time(852095746000L));
+    }
+
+    public boolean javaSql_encode_date(Object v) {
+        Date date = Date.valueOf("2020-08-09");
+        return date.equals(v);
+    }
+
+}

--- a/test_hessian/src/main/java/test/TestJavaSqlTime.java
+++ b/test_hessian/src/main/java/test/TestJavaSqlTime.java
@@ -17,33 +17,23 @@
 
 package test;
 
-import java.io.IOException;
 import java.sql.Date;
 import java.sql.Time;
-import java.text.SimpleDateFormat;
 
 public class TestJavaSqlTime {
 
-    public Object javaSql_decode_date() throws IOException {
+    public Object javaSql_decode_date() {
         Date date = Date.valueOf("2020-08-09");
         return date;
     }
 
-    public Object javaSql_decode_time() throws IOException {
+    public Object javaSql_decode_time() {
         Time time = new Time(852095746000L);
         return time;
     }
 
 
     public TestJavaSqlTime() {
-    }
-
-    public static void main(String[] args) {
-        long time = 894621091000L;
-
-        time -= time % 60000L;
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-        System.out.println(sdf.format(new java.util.Date(time)));
     }
 
     public static Object javaSql_encode_time(Object v) {


### PR DESCRIPTION
**What this PR does**:
java class java.sql.Time & java.sql.Date refer to hessian.Time & hessian.Date
**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
can use hessian.Time & hessian.Date in go for communicating with java.sql.Time & java.sql.Date in java
```release-note

```