### PR TITLE
Fix #253: Acquire sufficient bytes for string encoding buffers

### DIFF
--- a/string.go
+++ b/string.go
@@ -108,7 +108,8 @@ func encString(b []byte, v string) []byte {
 		byteCount int
 	)
 
-	bufp := gxbytes.AcquireBytes(CHUNK_SIZE * 3)
+	// Acquire (CHUNK_SIZE + 1) * 3 bytes since charCount could reach CHUNK_SIZE + 1.
+	bufp := gxbytes.AcquireBytes((CHUNK_SIZE + 1) * 3)
 	defer gxbytes.ReleaseBytes(bufp)
 	buf := *bufp
 

--- a/string_test.go
+++ b/string_test.go
@@ -111,6 +111,16 @@ func TestEncRune(t *testing.T) {
 	assertEqual([]byte(res.(string)), []byte(v), t)
 }
 
+func TestEncStringChunk(t *testing.T) {
+	enc := NewEncoder()
+	v := strings.Repeat("我", CHUNK_SIZE-1) + "🤣"
+	assert.Nil(t, enc.Encode(v))
+	dec := NewDecoder(enc.Buffer())
+	s, err := dec.Decode()
+	assert.Nil(t, err)
+	assert.Equal(t, v, s)
+}
+
 func TestString(t *testing.T) {
 	s0 := ""
 	s1 := "0"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

Acquire sufficient bytes for string encoding buffers.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #253 

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
- fix index out of range in some string encoding cases
```