### PR TITLE
Fix: Fixed getArgType reflection value logic

### DIFF
--- a/request.go
+++ b/request.go
@@ -103,7 +103,7 @@ func getArgType(v interface{}) string {
 	default:
 		t := reflect.TypeOf(v)
 		if reflect.Ptr == t.Kind() {
-			t = reflect.TypeOf(reflect.ValueOf(v).Elem())
+			t = t.Elem()
 		}
 		switch t.Kind() {
 		case reflect.Struct:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:
Fixed getArgType reflection value logic.

Source
![1630564699562_2A57E06F-1539-4bec-9869-C7369CF69DCA](https://user-images.githubusercontent.com/9605663/131800743-e375621c-1935-44ee-8273-e3d98fde2c89.png)

Demo
![1630564706769_6D073A5C-CF4C-43f4-BB6B-DDF36991CC4B](https://user-images.githubusercontent.com/9605663/131800815-71b34990-6405-4d97-bae5-dda8e803dae9.png)

Print
![1630564711927_CBBCA459-7108-4afc-888F-A86FA1F971BC](https://user-images.githubusercontent.com/9605663/131800878-3ee6dbe9-7b74-4f8c-9c8a-8b9acde00768.png)

Analyse
`发现原版指向的类型是struct，如果使用t.Elem()会指向slice`
`测试了map，结果也是相似的`

Conclusion
`当getArgType的switch跑到default，且入参为指针时，很可能都会当成一般struct去处理`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```