### PR TITLE
convert pointer to encode

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -476,3 +476,10 @@ func ConvertSliceValueType(destTyp reflect.Type, v reflect.Value) (reflect.Value
 
 	return sl, nil
 }
+
+//PackPtrInterface pack struct interface to pointer interface
+func PackPtrInterface(s interface{}, value reflect.Value) interface{} {
+	vv := reflect.New(reflect.TypeOf(s))
+	vv.Elem().Set(value)
+	return vv.Interface()
+}

--- a/codec_test.go
+++ b/codec_test.go
@@ -18,7 +18,12 @@
 package hessian
 
 import (
+	"reflect"
 	"testing"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
 )
 
 // go test -v -run TestPackUint16
@@ -56,4 +61,12 @@ func TestPackInt64(t *testing.T) {
 	if r := UnpackInt64(PackInt64(v)); r != v {
 		t.Fatalf("v:0X%d, pack-unpack value:0X%x\n", v, r)
 	}
+}
+
+func TestPackPtrInterface(t *testing.T) {
+	v := "struct"
+	vv := reflect.ValueOf(v)
+	sPointer, ok := PackPtrInterface(v, vv).(*string)
+	assert.True(t, ok)
+	assert.True(t, *sPointer == "struct")
 }

--- a/encode.go
+++ b/encode.go
@@ -160,7 +160,11 @@ func (e *Encoder) Encode(v interface{}) error {
 		switch t.Kind() {
 		case reflect.Struct:
 			vv := reflect.ValueOf(v)
-			vv = UnpackPtr(vv)
+			if vv.Kind() != reflect.Ptr {
+				v = PackPtrInterface(v, vv)
+			} else {
+				vv = UnpackPtr(vv)
+			}
 			if !vv.IsValid() {
 				e.buffer = EncNull(e.buffer)
 				return nil

--- a/encode_test.go
+++ b/encode_test.go
@@ -87,3 +87,53 @@ func testSimpleEncode(t *testing.T, v interface{}) {
 	err := e.Encode(v)
 	assert.Nil(t, err)
 }
+
+type BenchData struct {
+	name string
+}
+
+func (b *BenchData) JavaClassName() string {
+	return "test.bench.BenchData"
+}
+
+// Benchmark_Struct_Encode  	 2231869	       506.8 ns/op	     560 B/op	       7 allocs/op
+func Benchmark_Struct_Encode(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		NewEncoder().Encode(BenchData{})
+	}
+}
+
+// Benchmark_Pointer_Encode   	 2565778	       476.1 ns/op	     560 B/op	       7 allocs/op
+func Benchmark_Pointer_Encode(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		NewEncoder().Encode(&BenchData{})
+	}
+}
+
+// Benchmark_Struct_Encode_8   	 2307214	       519.4 ns/op	     560 B/op	       7 allocs/op
+func Benchmark_Struct_Encode_8(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.SetParallelism(8)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			NewEncoder().Encode(BenchData{})
+		}
+	})
+}
+
+// Benchmark_Pointer_Encode_8   	 2460842	       476.7 ns/op	     560 B/op	       7 allocs/op
+func Benchmark_Pointer_Encode_8(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.SetParallelism(8)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			NewEncoder().Encode(&BenchData{})
+		}
+	})
+}

--- a/serialize.go
+++ b/serialize.go
@@ -69,7 +69,7 @@ func (IntegerSerializer) DecObject(d *Decoder, typ reflect.Type, cls *classInfo)
 }
 
 func (IntegerSerializer) EncObject(e *Encoder, v POJO) error {
-	bigInt, ok := v.(bigInteger)
+	bigInt, ok := v.(*bigInteger)
 	if !ok {
 		return e.encObject(v)
 	}
@@ -80,7 +80,7 @@ func (IntegerSerializer) EncObject(e *Encoder, v POJO) error {
 type DecimalSerializer struct{}
 
 func (DecimalSerializer) EncObject(e *Encoder, v POJO) error {
-	decimal, ok := v.(big.Decimal)
+	decimal, ok := v.(*big.Decimal)
 	if !ok {
 		return e.encObject(v)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

When a user implements custom POJOs and uses non-pointer POJOs to encode, the encoding fails to transfer pojos forcibly. As a result, the program execution fails to meet expectations

![image](https://user-images.githubusercontent.com/28588342/141734262-63f2dc67-fa32-42f1-be55-3d6eeba2a020.png)



When non-pointer structures are encoded, they are uniformly converted to Pointers for encoding

、
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
Benchmark: 分别在struct以及pointer场景下 用串行以及8c并行 对当前pr与master进行对比。

// Benchmark_Struct_Encode  	 2231869	       506.8 ns/op	     560 B/op	       7 allocs/op
// Benchmark_Struct_Encode-master  	713761	      1549 ns/op	     560 B/op	       8 allocs/op

// Benchmark_Pointer_Encode   	 2565778	       476.1 ns/op	     560 B/op	       7 allocs/op
// Benchmark_Pointer_Encode-master   	 2328867	       511.4 ns/op	     576 B/op	       8 allocs/op

// Benchmark_Struct_Encode_8   	 2307214	       519.4 ns/op	     560 B/op	       7 allocs/op
// Benchmark_Struct_Encode_8-master   	 3104438	       387.6 ns/op	     560 B/op	       8 allocs/op

// Benchmark_Pointer_Encode_8   	 2460842	       476.7 ns/op	     560 B/op	       7 allocs/op
// Benchmark_Pointer_Encode_8-master   	 2254734	       514.9 ns/op	     576 B/op	       8 allocs/op

当前master 对于struct 是非指针并且receiver是指针的情况下 性能和当前pr差距较大，其他的情况差距都还好。