### PR TITLE
support java function param type

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,74 @@ type MyUser struct {
 
 ```
 
+#### Encoding param name
 
-##### hessian.SetTagIdentifier
+When a Java method declares an argument as a parent class, it actually hope receives a subclass，
+You can specify the encoding type of the parameter separately.
+
+##### java-server
+
+```java
+public abstract class User {
+}
+
+public class MyUser extends User implements Serializable {
+
+    private String userFullName;
+
+    private String familyPhoneNumber;
+}
+
+public interface UserProvider {
+    String GetUser(User user);
+}
+
+public class UserProviderImpl implements UserProvider {
+    public UserProviderImpl() {
+    }
+    
+    public String GetUser(User user) {
+        MyUser myUser=(MyUser)user;
+        return myUser.getUserFullName();
+    }
+}
+
+```
+
+##### go-client
+
+```go
+type MyUser struct {
+    UserFullName      string   `hessian:"userFullName"`
+    FamilyPhoneNumber string   // default convert to => familyPhoneNumber
+}
+
+func (m *MyUser) JavaClassName() string {
+    return "com.company.MyUser"
+}
+
+func (m *MyUser) JavaParamName() string {
+    return "com.company.User"
+}
+
+type UserProvider struct {
+    GetUser func(ctx context.Context, user *MyUser) (string, error) `dubbo:"GetUser"`
+}
+```
+
+
+
+#### Set method Alias
+
+When the Go client calls the Java server, the first letter of the method is converted to lowercase by default,you can use the dubbo tag to set method alias.
+
+```go
+type UserProvider struct {
+    GetUser func(ctx context.Context) (*User, error) `dubbo:"GetUser"`
+}
+```
+
+#### hessian.SetTagIdentifier
 
 You can use `hessian.SetTagIdentifier` to customize tag-identifier of hessian, which takes effect to both encoder and decoder.
 
@@ -237,6 +303,7 @@ The encoded bytes of the struct `MyUser` is as following:
 ```
 
 #### Using Java collections
+
 By default, the output of Hessian Java impl of a Java collection like java.util.HashSet will be decoded as `[]interface{}` in `go-hessian2`.
 To apply the one-to-one mapping relationship between certain Java collection class and your Go struct, examples are as follows:
 

--- a/param.go
+++ b/param.go
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hessian
+
+// Param interface
+// !!! Pls attention that Every field name should be upper case.
+// specifies the Java method parameter type.
+// if this interface is not implemented, the pojo javaClassName is
+// used as the method parameter type by default
+type Param interface {
+	POJO
+	JavaParamName() string
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:
Supports specifying the types of Java method parameters.
golang decode fails when the Java interface receives a parameter type of parent class and is actually passed a subclass
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/apache/dubbo-go-hessian2/issues/293

**Special notes for your reviewer**:
samples:
![image](https://user-images.githubusercontent.com/28588342/144013677-e7156e7e-5705-49da-a16f-3cf12834f7dd.png)

dubbo-go 修改点：
![image](https://user-images.githubusercontent.com/28588342/144013616-60301997-4669-4dd7-868f-1c2d52ef2460.png)



**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```