### PR TITLE
fix #305, Java Double type to float64 get error  when null value set

### DIFF
--- a/double.go
+++ b/double.go
@@ -146,6 +146,9 @@ func (d *Decoder) decDouble(flag int32) (interface{}, error) {
 		var f64 float64
 		err = binary.Read(d.reader, binary.BigEndian, &f64)
 		return f64, perrors.WithStack(err)
+
+	case BC_NULL:
+		return float64(0), nil
 	}
 
 	return nil, perrors.Errorf("decDouble parse double wrong tag:%d-%#x", int(tag), tag)

--- a/double_test.go
+++ b/double_test.go
@@ -18,6 +18,7 @@
 package hessian
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -69,7 +70,35 @@ func TestIssue181(t *testing.T) {
 	t.Logf("decode(%v) = %v\n", v, res)
 }
 
+func TestDoubleNull(t *testing.T) {
+	var (
+		v   float32
+		err error
+		d   *Decoder
+		res interface{}
+	)
+
+	// Double type with null value
+	d = NewDecoder([]byte{'C', 'N'})
+	res, err = d.Decode()
+	if err != nil {
+		t.Errorf("get error when decode %v", err)
+		return
+	}
+	f, ok := res.(float64)
+	if !ok {
+		t.Errorf("float64 is expected but %v", reflect.TypeOf(res))
+		return
+	}
+	if float32(f) != 0.0 {
+		t.Errorf("expect float32")
+		return
+	}
+	t.Logf("decode(%v) = %v\n", v, res)
+}
+
 func TestDouble(t *testing.T) {
+	testDecodeFramework(t, "replyNull", nil)
 	testDecodeFramework(t, "replyDouble_0_0", 0.0)
 	testDecodeFramework(t, "replyDouble_0_001", 0.001)
 	testDecodeFramework(t, "replyDouble_1_0", 1.0)
@@ -108,4 +137,18 @@ func TestDoublePrtEncode(t *testing.T) {
 	)
 	testSimpleEncode(t, &f0)
 	testSimpleEncode(t, &f1)
+}
+
+type score struct {
+	Score float64
+	Name  string
+}
+
+func (s score) JavaClassName() string {
+	return "test.Score"
+}
+
+func TestDecodeDoubleHasNull(t *testing.T) {
+	RegisterPOJO(&score{})
+	testDecodeFramework(t, "customReplyTypedDoubleHasNull", &score{Score: 0, Name: "DoubleWithNull"})
 }

--- a/test_hessian/src/main/java/test/TestCustomReply.java
+++ b/test_hessian/src/main/java/test/TestCustomReply.java
@@ -693,6 +693,35 @@ public class TestCustomReply {
         output.writeObject(map);
         output.flush();
     }
+
+    public void customReplyTypedDoubleHasNull() throws Exception {
+
+        Score s = new Score();
+        s.setScore(null);
+        s.setName("DoubleWithNull");
+        output.writeObject(s);
+        output.flush();
+    }
+}
+
+class Score implements Serializable {
+    private Double score;
+    private String name;
+
+    public void setName(String name) {
+        this.name = name;
+    }
+    public String getName() {
+        return this.name;
+    }
+
+    public void setScore(Double score) {
+        this.score = score;
+    }
+
+    public Double getScore() {
+        return this.score;
+    }
 }
 
 interface Leg {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
fix #305  https://github.com/apache/dubbo-go-hessian2/issues/305; return zero value float64 when java side set null to Double  .