### PR TITLE
mark array types deprecated

### DIFF
--- a/array.go
+++ b/array.go
@@ -33,6 +33,7 @@ func init() {
 }
 
 // BooleanArray Boolean[]
+// Deprecated: it will be replaced by a slice type instead in next major version.
 type BooleanArray struct {
 	Values []bool
 }
@@ -60,7 +61,8 @@ func (*BooleanArray) JavaClassName() string {
 	return "[java.lang.Boolean"
 }
 
-// IntegerArray Integer[]
+// IntegerArray Integer[].
+// Deprecated: it will be replaced by a slice type instead in next major version.
 type IntegerArray struct {
 	Values []int32
 }
@@ -89,6 +91,7 @@ func (*IntegerArray) JavaClassName() string {
 }
 
 // ByteArray Byte[]
+// Deprecated: it will be replaced by a slice type instead in next major version.
 type ByteArray struct {
 	Values []uint8
 }
@@ -117,6 +120,7 @@ func (*ByteArray) JavaClassName() string {
 }
 
 // ShortArray Short[]
+// Deprecated: it will be replaced by a slice type instead in next major version.
 type ShortArray struct {
 	Values []int16
 }
@@ -145,6 +149,7 @@ func (*ShortArray) JavaClassName() string {
 }
 
 // LongArray Long[]
+// Deprecated: it will be replaced by a slice type instead in next major version.
 type LongArray struct {
 	Values []int64
 }
@@ -173,6 +178,7 @@ func (*LongArray) JavaClassName() string {
 }
 
 // FloatArray Float[]
+// Deprecated: it will be replaced by a slice type instead in next major version.
 type FloatArray struct {
 	Values []float32
 }
@@ -201,6 +207,7 @@ func (*FloatArray) JavaClassName() string {
 }
 
 // DoubleArray Double[]
+// Deprecated: it will be replaced by a slice type instead in next major version.
 type DoubleArray struct {
 	Values []float64
 }
@@ -229,6 +236,7 @@ func (*DoubleArray) JavaClassName() string {
 }
 
 // CharacterArray Character[]
+// Deprecated: it will be replaced by a slice type instead in next major version.
 type CharacterArray struct {
 	Values string
 }

--- a/array.go
+++ b/array.go
@@ -33,7 +33,7 @@ func init() {
 }
 
 // BooleanArray Boolean[]
-// Deprecated: it will be replaced by a slice type instead in next major version.
+// Deprecated: it will not be supported in next major version, being replaced by a slice type instead.
 type BooleanArray struct {
 	Values []bool
 }
@@ -62,7 +62,7 @@ func (*BooleanArray) JavaClassName() string {
 }
 
 // IntegerArray Integer[].
-// Deprecated: it will be replaced by a slice type instead in next major version.
+// Deprecated: it will not be supported in next major version, being replaced by a slice type instead.
 type IntegerArray struct {
 	Values []int32
 }
@@ -91,7 +91,7 @@ func (*IntegerArray) JavaClassName() string {
 }
 
 // ByteArray Byte[]
-// Deprecated: it will be replaced by a slice type instead in next major version.
+// Deprecated: it will not be supported in next major version, being replaced by a slice type instead.
 type ByteArray struct {
 	Values []uint8
 }
@@ -120,7 +120,7 @@ func (*ByteArray) JavaClassName() string {
 }
 
 // ShortArray Short[]
-// Deprecated: it will be replaced by a slice type instead in next major version.
+// Deprecated: it will not be supported in next major version, being replaced by a slice type instead.
 type ShortArray struct {
 	Values []int16
 }
@@ -149,7 +149,7 @@ func (*ShortArray) JavaClassName() string {
 }
 
 // LongArray Long[]
-// Deprecated: it will be replaced by a slice type instead in next major version.
+// Deprecated: it will not be supported in next major version, being replaced by a slice type instead.
 type LongArray struct {
 	Values []int64
 }
@@ -178,7 +178,7 @@ func (*LongArray) JavaClassName() string {
 }
 
 // FloatArray Float[]
-// Deprecated: it will be replaced by a slice type instead in next major version.
+// Deprecated: it will not be supported in next major version, being replaced by a slice type instead.
 type FloatArray struct {
 	Values []float32
 }
@@ -207,7 +207,7 @@ func (*FloatArray) JavaClassName() string {
 }
 
 // DoubleArray Double[]
-// Deprecated: it will be replaced by a slice type instead in next major version.
+// Deprecated: it will not be supported in next major version, being replaced by a slice type instead.
 type DoubleArray struct {
 	Values []float64
 }
@@ -236,7 +236,7 @@ func (*DoubleArray) JavaClassName() string {
 }
 
 // CharacterArray Character[]
-// Deprecated: it will be replaced by a slice type instead in next major version.
+// Deprecated: it will not be supported in next major version, being replaced by a slice type instead.
 type CharacterArray struct {
 	Values string
 }


### PR DESCRIPTION

**What this PR does**:
mark array types deprecated,  to notice users the following types will not be supported in the next major version.
```go
hessian.IntegerArray
hessian.ByteArray
hessian.ShortArray
hessian.BooleanArray
hessian.LongArray
hessian.FloatArray
hessian.DoubleArray
hessian.CharacterArray
```