### PR TITLE
upgrade go to v1.17 to fix issue #348

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -19,7 +19,7 @@ jobs:
         os:
           - ubuntu-latest
         go_version:
-          - 1.13
+          - 1.17
         jdk_version:
           - 1.8
     env:

--- a/date.go
+++ b/date.go
@@ -42,12 +42,12 @@ func encDateInMs(b []byte, i interface{}) []byte {
 		return append(b, BC_NULL)
 	}
 	b = append(b, BC_DATE)
-	return append(b, PackInt64(vi.UnixNano()/1e6)...)
+	return append(b, PackInt64(vi.UnixMilli())...)
 }
 
-func encDateInMimute(b []byte, v time.Time) []byte {
+func encDateInMinute(b []byte, v time.Time) []byte {
 	b = append(b, BC_DATE_MINUTE)
-	return append(b, PackInt32(int32(v.UnixNano()/60e9))...)
+	return append(b, PackInt32(int32(v.Unix()/60))...)
 }
 
 /////////////////////////////////////////

--- a/date_test.go
+++ b/date_test.go
@@ -66,6 +66,22 @@ func TestEncDate(t *testing.T) {
 	d = NewDecoder(e.Buffer())
 	res, err = d.Decode()
 	t.Logf("decode(%s, %s) = %v, %v\n", v, tz.Local(), res, err)
+	assert.Equal(t, tz.Local(), res)
+}
+
+func TestEncDateIssue348(t *testing.T) {
+	e := NewEncoder()
+	v := "2914-02-09 06:15:23"
+	tz, _ := time.Parse("2006-01-02 15:04:05", v)
+	e.Encode(tz)
+	if len(e.Buffer()) == 0 {
+		t.Fail()
+	}
+
+	d := NewDecoder(e.Buffer())
+	res, err := d.Decode()
+	t.Logf("decode(%s, %s) = %v, %v\n", v, tz.Local(), res, err)
+	assert.Equal(t, tz.Local(), res)
 }
 
 func testDateFramework(t *testing.T, method string, expected time.Time) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:
- upgrade go from v1.13 to v1.17
- using `time.UnixMills` api to release time scope limit

**Which issue(s) this PR fixes**:

Fixes #348

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:

```release-note
upgrade go from v1.13 to v1.17, and to use `time.UnixMills` api to release time scope limit
```