### PR TITLE
fix pointer value set

### DIFF
--- a/date_test.go
+++ b/date_test.go
@@ -152,8 +152,8 @@ func TestEncDateNull(t *testing.T) {
 	assert.Equal(t, ZeroDate, res.(*DateDemo).Date)
 	assert.Equal(t, 2, len(res.(*DateDemo).Dates))
 	assert.Equal(t, tz.Local().String(), (*res.(*DateDemo).Dates[0]).String())
-	assert.Equal(t, &ZeroDate, res.(*DateDemo).NilDate)
-	assert.Equal(t, ZeroDate, *res.(*DateDemo).Date1)
+	assert.Nil(t, res.(*DateDemo).NilDate)
+	assert.Nil(t, res.(*DateDemo).Date1)
 	assert.Equal(t, tz.Local().String(), (*res.(*DateDemo).Date2).String())
 	assert.Equal(t, tz.Local().String(), (*(*res.(*DateDemo).Date3)).String())
 }
@@ -174,6 +174,6 @@ func doTestDateNull(t *testing.T, method string) {
 	testDecodeFrameworkFunc(t, method, func(r interface{}) {
 		t.Logf("%#v", r)
 		assert.Equal(t, ZeroDate, r.(*DateDemo).Date)
-		assert.Equal(t, &ZeroDate, r.(*DateDemo).Date1)
+		assert.Nil(t, r.(*DateDemo).Date1)
 	})
 }

--- a/list.go
+++ b/list.go
@@ -393,7 +393,7 @@ func (d *Decoder) readTypedListValue(length int, listTyp string, isVariableArr b
 		} else {
 			if it != nil {
 				//aryValue.Index(j).Set(EnsureRawValue(it))
-				setRawValueToDest(aryValue.Index(j), EnsureRawValue(it))
+				SetValue(aryValue.Index(j), EnsureRawValue(it))
 			}
 		}
 	}

--- a/object_test.go
+++ b/object_test.go
@@ -953,7 +953,7 @@ func TestCustomReplyGenericResponseBusinessData(t *testing.T) {
 	}
 	res := &GenericResponse{
 		Code: 201,
-		Data: data,
+		Data: &data,
 	}
 	RegisterPOJO(data)
 	RegisterPOJO(res)
@@ -1057,7 +1057,7 @@ func TestWrapperClassArray(t *testing.T) {
 }
 
 type User struct {
-	Id   int32
+	Id   *int32
 	List []int32
 }
 
@@ -1067,12 +1067,13 @@ func (u *User) JavaClassName() string {
 
 func TestDecodeIntegerHasNull(t *testing.T) {
 	RegisterPOJO(&User{})
-	testDecodeFramework(t, "customReplyTypedIntegerHasNull", &User{Id: 0})
+
+	testDecodeFramework(t, "customReplyTypedIntegerHasNull", &User{Id: nil})
 }
 
 func TestDecodeSliceIntegerHasNull(t *testing.T) {
 	RegisterPOJO(&User{})
-	testDecodeFramework(t, "customReplyTypedListIntegerHasNull", &User{Id: 0, List: []int32{1, 0}})
+	testDecodeFramework(t, "customReplyTypedListIntegerHasNull", &User{Id: nil, List: []int32{1, 0}})
 }
 
 func TestDecodeCustomReplyEnumVariableList(t *testing.T) {

--- a/ref.go
+++ b/ref.go
@@ -32,6 +32,9 @@ var _emptySliceAddr = unsafe.Pointer(reflect.ValueOf([]interface{}{}).Pointer())
 // The addresses of all nil map are the same.
 var _nilMapAddr = unsafe.Pointer(reflect.ValueOf(map[interface{}]interface{}(nil)).Pointer())
 
+// the ref holder type.
+var _refHolderType = reflect.TypeOf(&_refHolder{})
+
 // used to ref object,list,map
 type _refElem struct {
 	// record the kind of target, objects are the same only if the address and kind are the same

--- a/testcases/user/user_test.go
+++ b/testcases/user/user_test.go
@@ -53,5 +53,6 @@ func TestUserEncodeDecode(t *testing.T) {
 	decoder := hessian.NewDecoder(buf)
 	dec, err := decoder.Decode()
 	assert.Nil(t, err)
+
 	assert.Equal(t, u1, dec)
 }


### PR DESCRIPTION


**What this PR does**:
From v1.12.0, hessian starts to support pointer value ref to java wrapper types, but the unit tests does not fully cover all cases. This pr fixes the pointer value set. 

**Which issue(s) this PR fixes**:

Fixes #358

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
- fix pointer value set
```