### PR TITLE
fix index out of range panic

### DIFF
--- a/map.go
+++ b/map.go
@@ -297,6 +297,9 @@ func (d *Decoder) decMap(flag int32) (interface{}, error) {
 	case tag == BC_MAP_UNTYPED:
 		m = make(map[interface{}]interface{})
 		d.appendRefs(m)
+		if d.len() == 0 {
+			return nil, perrors.Errorf("the buffer is empty")
+		}
 		for d.peekByte() != BC_END {
 			k, err = d.Decode()
 			if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

Adds a size check, as `peekByte()` will otherwise panic with an index out of range.

PoC:

```go
package main

import (
        "testing"

        hessian "github.com/apache/dubbo-go-hessian2"
)

func TestPoC(t *testing.T) {
    body = []byte{0x48}
    decoder := hessian.NewDecoder(body)
    _, _ = decoder.Decode()
}
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```