### PR TITLE
fix Decoder failed to decode int8/int16 type values of map field in struct

### DIFF
--- a/map_test.go
+++ b/map_test.go
@@ -182,3 +182,42 @@ func TestJavaMap(t *testing.T) {
 	RegisterPOJO(customMap)
 	testJavaDecode(t, "customArgTypedFixed_CustomMap", customMap)
 }
+
+type Obj struct {
+	Map8  map[int8]int8
+	Map16 map[int16]int16
+	Map32 map[int32]int32
+}
+
+func (Obj) JavaClassName() string {
+	return ""
+}
+
+func TestMapInObject(t *testing.T) {
+	var (
+		obj Obj
+		e   *Encoder
+		d   *Decoder
+		err error
+		res interface{}
+	)
+
+	obj = Obj{
+		Map8:  map[int8]int8{1: 2, 3: 4},
+		Map16: map[int16]int16{1: 2, 3: 4},
+		Map32: map[int32]int32{1: 2, 3: 4},
+	}
+
+	e = NewEncoder()
+	e.Encode(obj)
+	if len(e.Buffer()) == 0 {
+		t.Fail()
+	}
+
+	d = NewDecoder(e.Buffer())
+	res, err = d.Decode()
+	if err != nil {
+		t.Errorf("Decode() = %+v", err)
+	}
+	t.Logf("decode(%v) = %v, %v\n", obj, res, err)
+}

--- a/map_test.go
+++ b/map_test.go
@@ -18,6 +18,7 @@
 package hessian
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -195,21 +196,21 @@ func (Obj) JavaClassName() string {
 
 func TestMapInObject(t *testing.T) {
 	var (
-		obj Obj
+		req *Obj
 		e   *Encoder
 		d   *Decoder
 		err error
 		res interface{}
 	)
 
-	obj = Obj{
+	req = &Obj{
 		Map8:  map[int8]int8{1: 2, 3: 4},
 		Map16: map[int16]int16{1: 2, 3: 4},
 		Map32: map[int32]int32{1: 2, 3: 4},
 	}
 
 	e = NewEncoder()
-	e.Encode(obj)
+	e.Encode(req)
 	if len(e.Buffer()) == 0 {
 		t.Fail()
 	}
@@ -219,5 +220,9 @@ func TestMapInObject(t *testing.T) {
 	if err != nil {
 		t.Errorf("Decode() = %+v", err)
 	}
-	t.Logf("decode(%v) = %v, %v\n", obj, res, err)
+	t.Logf("decode(%v) = %v, %v\n", req, res, err)
+
+	if !reflect.DeepEqual(req, res) {
+		t.Fatalf("req: %#v != res: %#v", req, res)
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

Fix Decoder failed to decode int8/int16 type values of map field in struct

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Currently, dubbo-go-hessian2 is unable to correctly decode values of type `int8` / `int16` that are contained within a `map` type field in a struct, resulting in a panic during the decoding process.

This PR is intended to fix this issue, which will enhance the compatibility between dubbo-go and dubbo-java.

**Special notes for your reviewer**:

I am a developer of the Kitex framework, and currently, [DubboCodec](https://github.com/kitex-contrib/codec-dubbo) is utilizing dubbo-go-hessian2 as its encoder/decoder. We also hope to resolve this issue through this PR, enabling us to support decoding of `int8` and `int16` types.

![img_v2_f5ff3858-80ba-4b3f-8e15-3794d2109ccg](https://github.com/apache/dubbo-go-hessian2/assets/92586826/0aba6ff9-e131-4d93-b882-13c6e8d49728)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```