### PR TITLE
support java null encoding

### DIFF
--- a/null_test.go
+++ b/null_test.go
@@ -34,6 +34,18 @@ func TestNull(t *testing.T) {
 	testDecodeFramework(t, "replyNull", nil)
 }
 
-func TestNulEncode(t *testing.T) {
+func TestNullEncode(t *testing.T) {
 	testJavaDecode(t, "argNull", nil)
+}
+
+func TestNullCompatibleEncode(t *testing.T) {
+	e := NewEncoder(
+		WithJavaNullCompatible(),
+	)
+	var null *int = nil
+	e.Encode(null)
+	if e.Buffer() == nil {
+		t.Fail()
+	}
+	assertEqual([]byte("N"), e.buffer, t)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

In the previous implementation, dubbo-go-hessian2 would encode `nil` values of a specified type as empty bytes.

For example:
```go
var null *int = nil

e := NewEncoder()
e.Encode(null)

len(e.buffer) == 0  // true
```

However, the expected encoding for `nil` values should be `[]byte("N")`, regardless of the type of `nil` value.

This PR addresses the above issue. It encodes `nil` values of any type as `[]byte("N")`.

To avoid impacting existing code, this feature is designed as an optional **option**.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->