### PR TITLE
bugfix: decode prefermance fix

### DIFF
--- a/decode_largedata_test.go
+++ b/decode_largedata_test.go
@@ -1,0 +1,93 @@
+package hessian
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func TestDecodeLargeData(t *testing.T) {
+	largeData := generateLargeMap(3, 5) // about 10MB
+
+	now := time.Now()
+	largeDataJson, err := json.Marshal(largeData)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("json serialize %s %dKB\n", time.Since(now), len(largeDataJson)/1024)
+	now = time.Now()
+
+	var data map[string]interface{}
+	err = json.Unmarshal(largeDataJson, &data)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("json deserialize %s\n", time.Since(now))
+	now = time.Now()
+
+	encoder := NewEncoder()
+	err = encoder.Encode(data)
+	if err != nil {
+		panic(err)
+	}
+	bytes := encoder.Buffer()
+	fmt.Printf("hessian2 serialize %s %dKB\n", time.Since(now), len(bytes)/1024)
+	now = time.Now()
+
+	now = time.Now()
+	decoder := NewDecoder(bytes)
+	obj, err := decoder.Decode()
+	if err != nil {
+		panic(err)
+	}
+	rt := time.Since(now)
+	fmt.Printf("hessian2 deserialize %s\n", rt)
+
+	if rt > 1*time.Second {
+		t.Error("deserialize too slow")
+	}
+	if fmt.Sprintf("%v", obj) != fmt.Sprintf("%v", data) {
+		t.Error("deserialize mismatched")
+	}
+}
+
+func generateLargeMap(depth int, size int) map[string]interface{} {
+	data := map[string]interface{}{}
+
+	if depth != 0 {
+		// generate sub map
+		for i := 0; i < size; i++ {
+			data[fmt.Sprintf("m%d", i)] = generateLargeMap(depth-1, size)
+		}
+
+		// generate sub list
+		for i := 0; i < size; i++ {
+			var sublist []interface{}
+			for j := 0; j < size; j++ {
+				sublist = append(sublist, generateLargeMap(depth-1, size))
+			}
+			data[fmt.Sprintf("l%d", i)] = sublist
+		}
+	}
+
+	// generate string element
+	for i := 0; i < size; i++ {
+		data[fmt.Sprintf("s%d", i)] = generateRandomString()
+	}
+	// generate int element
+	for i := 0; i < size; i++ {
+		data[fmt.Sprintf("i%d", i)] = rand.Int31()
+	}
+	// generate float element
+	for i := 0; i < size; i++ {
+		data[fmt.Sprintf("f%d", i)] = rand.Float32()
+	}
+
+	return data
+}
+
+func generateRandomString() string {
+	return "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"[rand.Int31n(20):]
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:
decode.go 里面的 Decode() 每次在解析map或list时都会触发一次对 d.refHolders 的轮询 notify()，在解析复杂对象时（我的场景需要处理约10M的数据），这个 Decode() 会被疯狂递归调用，无数次对这个 d.refHolders() 进行无用的 notify()，产生严重的性能问题

我的机器是 MacBook Pro M3Pro  36G，在我本机上，处理10M的数据时，rt将达到5秒。此性能不可接受。

本次改动对 Decode() 的递归次数进行计数，只在最外层的 Decode() 时进行 notify() 操作。

可以通过MR中的 decode_largedata_test.go 验证。此测试用例随机生成一个巨大的map/list相互嵌套的结构并执行序列化/反序列化操作。未引入我的修改时，反序列化的rt远高于序列化（秒级）。引入此修改后序列化与反序列化rt持平（毫秒级）

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```