### PR TITLE
fix: validate low surrogate before combining surrogate pair in decode2utf8

### DIFF
--- a/string.go
+++ b/string.go
@@ -384,14 +384,16 @@ func decode2utf8(r *bufio.Reader, data []byte, start, end int) (int, int, int, e
 				}
 
 				c2 := ((uint32(data[start+3]) & 0x0f) << 12) + ((uint32(data[start+4]) & 0x3f) << 6) + (uint32(data[start+5]) & 0x3f)
-				c := (c1-0xD800)<<10 + (c2 - 0xDC00) + 0x10000
+				if c2 >= 0xDC00 && c2 <= 0xDFFF {
+					c := (c1-0xD800)<<10 + (c2 - 0xDC00) + 0x10000
 
-				n := utf8.EncodeRune(data[start:], rune(c))
-				copy(data[start+n:], data[start+6:end])
-				start, end = start+n, end-6+n
+					n := utf8.EncodeRune(data[start:], rune(c))
+					copy(data[start+n:], data[start+6:end])
+					start, end = start+n, end-6+n
 
-				charCount += 2
-				continue
+					charCount += 2
+					continue
+				}
 			}
 
 			start += 3

--- a/string_test.go
+++ b/string_test.go
@@ -233,6 +233,29 @@ func TestStringComplex(t *testing.T) {
 	testJavaDecode(t, "customArgComplexString", s0)
 }
 
+// TestDecodeStringLoneHighSurrogateRealWorld reproduces the real-world string
+// "test_go_hessian2\ud83d..." sent by a Java hessian2 encoder.
+//
+// Java encodes lone surrogates as 3-byte CESU-8: U+D83D → 0xED 0xA0 0xBD.
+// The following "..." bytes (0x2E 0x2E 0x2E) decode to c2 = 0x002E, which is
+// outside [0xDC00, 0xDFFF].  Before the fix decode2utf8 combined them
+// unconditionally, corrupting the suffix; the fix skips the combination.
+func TestDecodeStringLoneHighSurrogateRealWorld(t *testing.T) {
+	// Byte stream produced by Java hessian2 for "test_go_hessian2\ud83d..."
+	serialized := []byte{
+		0x14,                                     // BC_STRING_DIRECT, 20 chars
+		0x74, 0x65, 0x73, 0x74, 0x5F, 0x67, 0x6F, // test_go
+		0x5F, 0x68, 0x65, 0x73, 0x73, 0x69, 0x61, 0x6E, 0x32, // _hessian2
+		0xED, 0xA0, 0xBD, // lone high surrogate U+D83D (CESU-8)
+		0x2E, 0x2E, 0x2E, // ...
+	}
+
+	d := NewDecoder(serialized)
+	got, err := d.Decode()
+	assert.Nil(t, err)
+	assert.Equal(t, "test_go_hessian2\xed\xa0\xbd...", got)
+}
+
 func BenchmarkDecodeStringAscii(b *testing.B) {
 	runBenchmarkDecodeString(b, "hello world, hello hessian")
 }


### PR DESCRIPTION
## Problem

When a Java client sends a string containing a lone high surrogate (e.g. `\ud83d`), `decode2utf8` unconditionally combines the following 3 bytes as a low surrogate, even when those bytes do not encode a value in the low-surrogate range `[0xDC00, 0xDFFF]`, corrupting the characters that follow.

**Reproducer**: `"test_go_hessian2\ud83d..."` — `\ud83d` is a lone high surrogate followed by `...` (`0x2E 0x2E 0x2E`, c2 = 0x002E), which is outside the low-surrogate range.

## Fix

Add a guard `if c2 >= 0xDC00 && c2 <= 0xDFFF` in `decode2utf8` after reading the candidate low-surrogate bytes. The surrogate pair is only combined when a valid low surrogate follows; otherwise the high surrogate is left as an independent 3-byte sequence and decoding continues normally.

## Test

Added `TestDecodeStringLoneHighSurrogateRealWorld` using a byte stream captured directly from Java hessian2 via `Hessian2Output.writeString`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)