### PR TITLE
test: verify typed nil scalar pointers encode as null

### DIFF
--- a/null_test.go
+++ b/null_test.go
@@ -68,6 +68,31 @@ func TestNullInt32Ptr(t *testing.T) {
 	assertEqual([]byte("N"), e.buffer, t)
 }
 
+func TestNullTypedScalarPointers(t *testing.T) {
+	tests := []struct {
+		name  string
+		value interface{}
+	}{
+		{name: "int32", value: (*int32)(nil)},
+		{name: "bool", value: (*bool)(nil)},
+		{name: "string", value: (*string)(nil)},
+		{name: "float64", value: (*float64)(nil)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := NewEncoder()
+			if err := e.Encode(tt.value); err != nil {
+				t.Fatalf("encode typed nil %s pointer: %v", tt.name, err)
+			}
+			if e.Buffer() == nil {
+				t.Fatal("expected encoder buffer")
+			}
+			assertEqual([]byte("N"), e.buffer, t)
+		})
+	}
+}
+
 func TestNullSlice(t *testing.T) {
 	e := NewEncoder()
 	var null []int32 = nil


### PR DESCRIPTION
### Description

Refs apache/dubbo-go#2517  
Refs #376  
Refs #384

### Why

PR #376 and PR #384 both try to fix typed nil pointer encoding by adding a generic reflect-based nil pointer check at the beginning of `Encoder.Encode`.

After checking current `master`, the specific hessian2 case reported in apache/dubbo-go#2517 is already handled:

- `(*int32)(nil)` is routed to `encTypeInt32`
- `encTypeInt32` already returns Hessian null (`N`) for nil pointers
- the existing `TestNullInt32Ptr` already covers the exact `(*int32)(nil)` case

So the right follow-up is not another production-code change. The useful missing piece is a focused boundary test proving that typed nil scalar pointers are already encoded as Hessian null on current `master`.

### Root Cause:

The old issue report was correct at the time: `v == nil` alone cannot detect typed nil pointers such as `(*int32)(nil)`.

However, current `master` already handles the reported hessian2 path through the existing typed int32 encoder logic. The remaining confusion comes from the lack of an explicit boundary test covering typed nil scalar pointers together.

### PR Goal:

Add a verification-only test PR that proves typed nil scalar pointers encode as Hessian null.

Provide clear evidence that #376 and #384 are no longer needed as production-code fixes.

Avoid adding a broad generic reflect nil-pointer branch to `Encoder.Encode` when the reported behavior is already covered by existing encoder paths.

### Success Criteria:

`(*int32)(nil)` encodes to Hessian null (`N`).

Other typed nil scalar pointers covered by this test also encode to Hessian null (`N`):

- `(*bool)(nil)`
- `(*string)(nil)`
- `(*float64)(nil)`

No production code is changed.

`go test ./...` passes.

### Paths this PR should affect:

`null_test.go`

### Revise

Adding `TestNullTypedScalarPointers`: proves typed nil scalar pointers are encoded as Hessian null on current `master`.

Keeping production code unchanged: avoids duplicating #376/#384's generic reflect check and keeps encoder behavior scoped to existing implementation paths.

Using `Refs` instead of `Fixes`: apache/dubbo-go#2517 also mentions dubbo-go protocol-layer error propagation, so this hessian2 PR should not claim to close the whole cross-repo issue by itself.

### Tests

```bash
go test ./...
```