### PR TITLE
fix(java_exception): populate dubbo generic exception message

### DIFF
--- a/java_exception/dubbo_generic_exception.go
+++ b/java_exception/dubbo_generic_exception.go
@@ -32,6 +32,7 @@ type DubboGenericException struct {
 func NewDubboGenericException(exceptionClass, exceptionMessage string) *DubboGenericException {
 	return &DubboGenericException{
 		DetailMessage:    formatDubboGenericExceptionMessage(exceptionClass, exceptionMessage),
+		StackTrace:       []StackTraceElement{},
 		ExceptionClass:   exceptionClass,
 		ExceptionMessage: exceptionMessage,
 	}

--- a/java_exception/dubbo_generic_exception.go
+++ b/java_exception/dubbo_generic_exception.go
@@ -30,12 +30,29 @@ type DubboGenericException struct {
 
 // NewDubboGenericException is the constructor
 func NewDubboGenericException(exceptionClass, exceptionMessage string) *DubboGenericException {
-	return &DubboGenericException{ExceptionClass: exceptionClass, ExceptionMessage: exceptionMessage}
+	return &DubboGenericException{
+		DetailMessage:    formatDubboGenericExceptionMessage(exceptionClass, exceptionMessage),
+		ExceptionClass:   exceptionClass,
+		ExceptionMessage: exceptionMessage,
+	}
 }
 
 // Error output error message
 func (e DubboGenericException) Error() string {
-	return e.DetailMessage
+	if e.DetailMessage != "" {
+		return e.DetailMessage
+	}
+	return formatDubboGenericExceptionMessage(e.ExceptionClass, e.ExceptionMessage)
+}
+
+func formatDubboGenericExceptionMessage(exceptionClass, exceptionMessage string) string {
+	if exceptionClass == "" {
+		return exceptionMessage
+	}
+	if exceptionMessage == "" {
+		return exceptionClass
+	}
+	return "java exception: " + exceptionClass + " - " + exceptionMessage
 }
 
 // JavaClassName  java fully qualified path

--- a/java_exception/dubbo_generic_exception_test.go
+++ b/java_exception/dubbo_generic_exception_test.go
@@ -54,6 +54,8 @@ func TestNewDubboGenericExceptionErrorMessage(t *testing.T) {
 			assert.Equal(t, test.exceptionClass, exception.ExceptionClass)
 			assert.Equal(t, test.exceptionMessage, exception.ExceptionMessage)
 			assert.Equal(t, test.wantError, exception.DetailMessage)
+			assert.NotNil(t, exception.StackTrace)
+			assert.Empty(t, exception.StackTrace)
 			assert.Equal(t, test.wantError, exception.Error())
 		})
 	}

--- a/java_exception/dubbo_generic_exception_test.go
+++ b/java_exception/dubbo_generic_exception_test.go
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package java_exception
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewDubboGenericExceptionErrorMessage(t *testing.T) {
+	tests := []struct {
+		name             string
+		exceptionClass   string
+		exceptionMessage string
+		wantError        string
+	}{
+		{
+			name:             "class and message",
+			exceptionClass:   "com.example.UserNotFoundException",
+			exceptionMessage: "user not found",
+			wantError:        "java exception: com.example.UserNotFoundException - user not found",
+		},
+		{
+			name:             "message only",
+			exceptionMessage: "user not found",
+			wantError:        "user not found",
+		},
+		{
+			name:           "class only",
+			exceptionClass: "com.example.UserNotFoundException",
+			wantError:      "com.example.UserNotFoundException",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			exception := NewDubboGenericException(test.exceptionClass, test.exceptionMessage)
+			assert.Equal(t, test.exceptionClass, exception.ExceptionClass)
+			assert.Equal(t, test.exceptionMessage, exception.ExceptionMessage)
+			assert.Equal(t, test.wantError, exception.DetailMessage)
+			assert.Equal(t, test.wantError, exception.Error())
+		})
+	}
+}
+
+func TestDubboGenericExceptionErrorFallback(t *testing.T) {
+	exception := DubboGenericException{
+		ExceptionClass:   "com.example.UserNotFoundException",
+		ExceptionMessage: "user not found",
+	}
+
+	assert.Equal(t, "java exception: com.example.UserNotFoundException - user not found", exception.Error())
+}
+
+func TestDubboGenericExceptionErrorPrefersDetailMessage(t *testing.T) {
+	exception := DubboGenericException{
+		DetailMessage:    "decoded detail",
+		ExceptionClass:   "com.example.UserNotFoundException",
+		ExceptionMessage: "user not found",
+	}
+
+	assert.Equal(t, "decoded detail", exception.Error())
+}

--- a/java_exception/dubbo_generic_exception_test.go
+++ b/java_exception/dubbo_generic_exception_test.go
@@ -19,7 +19,9 @@ package java_exception
 
 import (
 	"testing"
+)
 
+import (
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
### Description

Related to apache/dubbo-go#3361 and apache/dubbo-go#3378.

This PR completes the hessian2-side part of moving Dubbo generic exception handling into dubbo-go-hessian2. `DubboGenericException` already carries `ExceptionClass` and `ExceptionMessage`; this change makes the constructor and `Error()` expose a stable detail message from those fields so callers do not need to duplicate message formatting in dubbo-go.

The behavior remains compatible with decoded Java exceptions: when `DetailMessage` is already populated by decoding, `Error()` keeps returning that decoded detail. When it is empty, `Error()` falls back to the generic exception class/message formatting that dubbo-go previously implemented locally.

### Validation

- `go test ./java_exception`
- `go test . -run TestException`
- `go test ./...`
- `git diff --check`
- local audit script (`OVERALL_EXIT=0`)
